### PR TITLE
Bundle with Rollup instead of Webpack

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,988 +1,541 @@
-!(function(modules) {
-  var installedModules = {};
-  function __webpack_require__(moduleId) {
-    if (installedModules[moduleId]) return installedModules[moduleId].exports;
-    var module = (installedModules[moduleId] = {
-      i: moduleId,
-      l: !1,
-      exports: {}
-    });
+import reactIs from "react-is";
+function _inheritsLoose(subClass, superClass) {
+  (subClass.prototype = Object.create(superClass.prototype)),
+    (subClass.prototype.constructor = subClass),
+    (subClass.__proto__ = superClass);
+}
+var commonjsGlobal =
+  "undefined" != typeof window
+    ? window
+    : "undefined" != typeof global
+    ? global
+    : "undefined" != typeof self
+    ? self
+    : {};
+function unwrapExports(x) {
+  return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, "default")
+    ? x.default
+    : x;
+}
+function createCommonjsModule(fn, module) {
+  return fn((module = { exports: {} }), module.exports), module.exports;
+}
+var getOwnPropertySymbols = Object.getOwnPropertySymbols,
+  hasOwnProperty = Object.prototype.hasOwnProperty,
+  propIsEnumerable = Object.prototype.propertyIsEnumerable;
+var objectAssign = (function() {
+    try {
+      if (!Object.assign) return !1;
+      var test1 = new String("abc");
+      if (((test1[5] = "de"), "5" === Object.getOwnPropertyNames(test1)[0]))
+        return !1;
+      for (var test2 = {}, i = 0; i < 10; i++)
+        test2["_" + String.fromCharCode(i)] = i;
+      if (
+        "0123456789" !==
+        Object.getOwnPropertyNames(test2)
+          .map(function(n) {
+            return test2[n];
+          })
+          .join("")
+      )
+        return !1;
+      var test3 = {};
+      return (
+        "abcdefghijklmnopqrst".split("").forEach(function(letter) {
+          test3[letter] = letter;
+        }),
+        "abcdefghijklmnopqrst" ===
+          Object.keys(Object.assign({}, test3)).join("")
+      );
+    } catch (err) {
+      return !1;
+    }
+  })()
+    ? Object.assign
+    : function(target, source) {
+        for (
+          var from,
+            symbols,
+            to = (function(val) {
+              if (null == val)
+                throw new TypeError(
+                  "Object.assign cannot be called with null or undefined"
+                );
+              return Object(val);
+            })(target),
+            s = 1;
+          s < arguments.length;
+          s++
+        ) {
+          for (var key in (from = Object(arguments[s])))
+            hasOwnProperty.call(from, key) && (to[key] = from[key]);
+          if (getOwnPropertySymbols) {
+            symbols = getOwnPropertySymbols(from);
+            for (var i = 0; i < symbols.length; i++)
+              propIsEnumerable.call(from, symbols[i]) &&
+                (to[symbols[i]] = from[symbols[i]]);
+          }
+        }
+        return to;
+      },
+  n = "function" == typeof Symbol && Symbol.for,
+  p = n ? Symbol.for("react.element") : 60103,
+  q = n ? Symbol.for("react.portal") : 60106,
+  r = n ? Symbol.for("react.fragment") : 60107,
+  t = n ? Symbol.for("react.strict_mode") : 60108,
+  u = n ? Symbol.for("react.profiler") : 60114,
+  v = n ? Symbol.for("react.provider") : 60109,
+  w = n ? Symbol.for("react.context") : 60110,
+  x = n ? Symbol.for("react.concurrent_mode") : 60111,
+  y = n ? Symbol.for("react.forward_ref") : 60112,
+  z = n ? Symbol.for("react.suspense") : 60113,
+  aa = n ? Symbol.for("react.memo") : 60115,
+  ba = n ? Symbol.for("react.lazy") : 60116,
+  A = "function" == typeof Symbol && Symbol.iterator;
+function B(a) {
+  for (
+    var b = arguments.length - 1,
+      d = "https://reactjs.org/docs/error-decoder.html?invariant=" + a,
+      c = 0;
+    c < b;
+    c++
+  )
+    d += "&args[]=" + encodeURIComponent(arguments[c + 1]);
+  !(function(a, b, d, c, e, g, h, f) {
+    if (!a) {
+      if (((a = void 0), void 0 === b))
+        a = Error(
+          "Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings."
+        );
+      else {
+        var l = [d, c, e, g, h, f],
+          m = 0;
+        (a = Error(
+          b.replace(/%s/g, function() {
+            return l[m++];
+          })
+        )).name = "Invariant Violation";
+      }
+      throw ((a.framesToPop = 1), a);
+    }
+  })(
+    !1,
+    "Minified React error #" +
+      a +
+      "; visit %s for the full message or use the non-minified dev environment for full errors and additional helpful warnings. ",
+    d
+  );
+}
+var C = {
+    isMounted: function() {
+      return !1;
+    },
+    enqueueForceUpdate: function() {},
+    enqueueReplaceState: function() {},
+    enqueueSetState: function() {}
+  },
+  D = {};
+function E(a, b, d) {
+  (this.props = a),
+    (this.context = b),
+    (this.refs = D),
+    (this.updater = d || C);
+}
+function F() {}
+function G(a, b, d) {
+  (this.props = a),
+    (this.context = b),
+    (this.refs = D),
+    (this.updater = d || C);
+}
+(E.prototype.isReactComponent = {}),
+  (E.prototype.setState = function(a, b) {
+    "object" != typeof a && "function" != typeof a && null != a && B("85"),
+      this.updater.enqueueSetState(this, a, b, "setState");
+  }),
+  (E.prototype.forceUpdate = function(a) {
+    this.updater.enqueueForceUpdate(this, a, "forceUpdate");
+  }),
+  (F.prototype = E.prototype);
+var H = (G.prototype = new F());
+(H.constructor = G),
+  objectAssign(H, E.prototype),
+  (H.isPureReactComponent = !0);
+var I = { current: null },
+  J = { current: null },
+  K = Object.prototype.hasOwnProperty,
+  L = { key: !0, ref: !0, __self: !0, __source: !0 };
+function M(a, b, d) {
+  var c = void 0,
+    e = {},
+    g = null,
+    h = null;
+  if (null != b)
+    for (c in (void 0 !== b.ref && (h = b.ref),
+    void 0 !== b.key && (g = "" + b.key),
+    b))
+      K.call(b, c) && !L.hasOwnProperty(c) && (e[c] = b[c]);
+  var f = arguments.length - 2;
+  if (1 === f) e.children = d;
+  else if (1 < f) {
+    for (var l = Array(f), m = 0; m < f; m++) l[m] = arguments[m + 2];
+    e.children = l;
+  }
+  if (a && a.defaultProps)
+    for (c in (f = a.defaultProps)) void 0 === e[c] && (e[c] = f[c]);
+  return { $$typeof: p, type: a, key: g, ref: h, props: e, _owner: J.current };
+}
+function N(a) {
+  return "object" == typeof a && null !== a && a.$$typeof === p;
+}
+var O = /\/+/g,
+  P = [];
+function Q(a, b, d, c) {
+  if (P.length) {
+    var e = P.pop();
     return (
-      modules[moduleId].call(
-        module.exports,
-        module,
-        module.exports,
-        __webpack_require__
-      ),
-      (module.l = !0),
-      module.exports
+      (e.result = a),
+      (e.keyPrefix = b),
+      (e.func = d),
+      (e.context = c),
+      (e.count = 0),
+      e
     );
   }
-  (__webpack_require__.m = modules),
-    (__webpack_require__.c = installedModules),
-    (__webpack_require__.d = function(exports, name, getter) {
-      __webpack_require__.o(exports, name) ||
-        Object.defineProperty(exports, name, { enumerable: !0, get: getter });
-    }),
-    (__webpack_require__.r = function(exports) {
-      "undefined" != typeof Symbol &&
-        Symbol.toStringTag &&
-        Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" }),
-        Object.defineProperty(exports, "__esModule", { value: !0 });
-    }),
-    (__webpack_require__.t = function(value, mode) {
-      if ((1 & mode && (value = __webpack_require__(value)), 8 & mode))
-        return value;
-      if (4 & mode && "object" == typeof value && value && value.__esModule)
-        return value;
-      var ns = Object.create(null);
-      if (
-        (__webpack_require__.r(ns),
-        Object.defineProperty(ns, "default", { enumerable: !0, value: value }),
-        2 & mode && "string" != typeof value)
-      )
-        for (var key in value)
-          __webpack_require__.d(
-            ns,
-            key,
-            function(key) {
-              return value[key];
-            }.bind(null, key)
-          );
-      return ns;
-    }),
-    (__webpack_require__.n = function(module) {
-      var getter =
-        module && module.__esModule
-          ? function() {
-              return module.default;
-            }
-          : function() {
-              return module;
-            };
-      return __webpack_require__.d(getter, "a", getter), getter;
-    }),
-    (__webpack_require__.o = function(object, property) {
-      return Object.prototype.hasOwnProperty.call(object, property);
-    }),
-    (__webpack_require__.p = ""),
-    __webpack_require__((__webpack_require__.s = 18));
-})([
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    module.exports = __webpack_require__(7);
-  },
-  function(module, exports, __webpack_require__) {
-    module.exports = __webpack_require__(9)();
-  },
-  function(module, exports, __webpack_require__) {
-    var isarray = __webpack_require__(16);
-    (module.exports = pathToRegexp),
-      (module.exports.parse = parse),
-      (module.exports.compile = function(str, options) {
-        return tokensToFunction(parse(str, options));
-      }),
-      (module.exports.tokensToFunction = tokensToFunction),
-      (module.exports.tokensToRegExp = tokensToRegExp);
-    var PATH_REGEXP = new RegExp(
-      [
-        "(\\\\.)",
-        "([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))"
-      ].join("|"),
-      "g"
-    );
-    function parse(str, options) {
-      for (
-        var res,
-          tokens = [],
-          key = 0,
-          index = 0,
-          path = "",
-          defaultDelimiter = (options && options.delimiter) || "/";
-        null != (res = PATH_REGEXP.exec(str));
-
-      ) {
-        var m = res[0],
-          escaped = res[1],
-          offset = res.index;
-        if (
-          ((path += str.slice(index, offset)),
-          (index = offset + m.length),
-          escaped)
+  return { result: a, keyPrefix: b, func: d, context: c, count: 0 };
+}
+function R(a) {
+  (a.result = null),
+    (a.keyPrefix = null),
+    (a.func = null),
+    (a.context = null),
+    (a.count = 0),
+    10 > P.length && P.push(a);
+}
+function U(a, b, d) {
+  return null == a
+    ? 0
+    : (function S(a, b, d, c) {
+        var e = typeof a;
+        ("undefined" !== e && "boolean" !== e) || (a = null);
+        var g = !1;
+        if (null === a) g = !0;
+        else
+          switch (e) {
+            case "string":
+            case "number":
+              g = !0;
+              break;
+            case "object":
+              switch (a.$$typeof) {
+                case p:
+                case q:
+                  g = !0;
+              }
+          }
+        if (g) return d(c, a, "" === b ? "." + T(a, 0) : b), 1;
+        if (((g = 0), (b = "" === b ? "." : b + ":"), Array.isArray(a)))
+          for (var h = 0; h < a.length; h++) {
+            var f = b + T((e = a[h]), h);
+            g += S(e, f, d, c);
+          }
+        else if (
+          ((f =
+            null === a || "object" != typeof a
+              ? null
+              : "function" == typeof (f = (A && a[A]) || a["@@iterator"])
+              ? f
+              : null),
+          "function" == typeof f)
         )
-          path += escaped[1];
-        else {
-          var next = str[index],
-            prefix = res[2],
-            name = res[3],
-            capture = res[4],
-            group = res[5],
-            modifier = res[6],
-            asterisk = res[7];
-          path && (tokens.push(path), (path = ""));
-          var partial = null != prefix && null != next && next !== prefix,
-            repeat = "+" === modifier || "*" === modifier,
-            optional = "?" === modifier || "*" === modifier,
-            delimiter = res[2] || defaultDelimiter,
-            pattern = capture || group;
-          tokens.push({
-            name: name || key++,
-            prefix: prefix || "",
-            delimiter: delimiter,
-            optional: optional,
-            repeat: repeat,
-            partial: partial,
-            asterisk: !!asterisk,
-            pattern: pattern
-              ? escapeGroup(pattern)
-              : asterisk
-              ? ".*"
-              : "[^" + escapeString(delimiter) + "]+?"
-          });
-        }
-      }
-      return (
-        index < str.length && (path += str.substr(index)),
-        path && tokens.push(path),
-        tokens
-      );
-    }
-    function encodeURIComponentPretty(str) {
-      return encodeURI(str).replace(/[\/?#]/g, function(c) {
+          for (a = f.call(a), h = 0; !(e = a.next()).done; )
+            g += S((e = e.value), (f = b + T(e, h++)), d, c);
+        else
+          "object" === e &&
+            B(
+              "31",
+              "[object Object]" == (d = "" + a)
+                ? "object with keys {" + Object.keys(a).join(", ") + "}"
+                : d,
+              ""
+            );
+        return g;
+      })(a, "", b, d);
+}
+function T(a, b) {
+  return "object" == typeof a && null !== a && null != a.key
+    ? (function(a) {
+        var b = { "=": "=0", ":": "=2" };
         return (
-          "%" +
-          c
-            .charCodeAt(0)
-            .toString(16)
-            .toUpperCase()
+          "$" +
+          ("" + a).replace(/[=:]/g, function(a) {
+            return b[a];
+          })
         );
-      });
-    }
-    function tokensToFunction(tokens) {
-      for (
-        var matches = new Array(tokens.length), i = 0;
-        i < tokens.length;
-        i++
-      )
-        "object" == typeof tokens[i] &&
-          (matches[i] = new RegExp("^(?:" + tokens[i].pattern + ")$"));
-      return function(obj, opts) {
-        for (
-          var path = "",
-            data = obj || {},
-            encode = (opts || {}).pretty
-              ? encodeURIComponentPretty
-              : encodeURIComponent,
-            i = 0;
-          i < tokens.length;
-          i++
-        ) {
-          var token = tokens[i];
-          if ("string" != typeof token) {
-            var segment,
-              value = data[token.name];
-            if (null == value) {
-              if (token.optional) {
-                token.partial && (path += token.prefix);
-                continue;
-              }
-              throw new TypeError(
-                'Expected "' + token.name + '" to be defined'
-              );
-            }
-            if (isarray(value)) {
-              if (!token.repeat)
-                throw new TypeError(
-                  'Expected "' +
-                    token.name +
-                    '" to not repeat, but received `' +
-                    JSON.stringify(value) +
-                    "`"
-                );
-              if (0 === value.length) {
-                if (token.optional) continue;
-                throw new TypeError(
-                  'Expected "' + token.name + '" to not be empty'
-                );
-              }
-              for (var j = 0; j < value.length; j++) {
-                if (((segment = encode(value[j])), !matches[i].test(segment)))
-                  throw new TypeError(
-                    'Expected all "' +
-                      token.name +
-                      '" to match "' +
-                      token.pattern +
-                      '", but received `' +
-                      JSON.stringify(segment) +
-                      "`"
-                  );
-                path += (0 === j ? token.prefix : token.delimiter) + segment;
-              }
-            } else {
-              if (
-                ((segment = token.asterisk
-                  ? encodeURI(value).replace(/[?#]/g, function(c) {
-                      return (
-                        "%" +
-                        c
-                          .charCodeAt(0)
-                          .toString(16)
-                          .toUpperCase()
-                      );
-                    })
-                  : encode(value)),
-                !matches[i].test(segment))
-              )
-                throw new TypeError(
-                  'Expected "' +
-                    token.name +
-                    '" to match "' +
-                    token.pattern +
-                    '", but received "' +
-                    segment +
-                    '"'
-                );
-              path += token.prefix + segment;
-            }
-          } else path += token;
-        }
-        return path;
-      };
-    }
-    function escapeString(str) {
-      return str.replace(/([.+*?=^!:${}()[\]|\/\\])/g, "\\$1");
-    }
-    function escapeGroup(group) {
-      return group.replace(/([=!:$\/()])/g, "\\$1");
-    }
-    function attachKeys(re, keys) {
-      return (re.keys = keys), re;
-    }
-    function flags(options) {
-      return options.sensitive ? "" : "i";
-    }
-    function tokensToRegExp(tokens, keys, options) {
-      isarray(keys) || ((options = keys || options), (keys = []));
-      for (
-        var strict = (options = options || {}).strict,
-          end = !1 !== options.end,
-          route = "",
-          i = 0;
-        i < tokens.length;
-        i++
-      ) {
-        var token = tokens[i];
-        if ("string" == typeof token) route += escapeString(token);
-        else {
-          var prefix = escapeString(token.prefix),
-            capture = "(?:" + token.pattern + ")";
-          keys.push(token),
-            token.repeat && (capture += "(?:" + prefix + capture + ")*"),
-            (route += capture = token.optional
-              ? token.partial
-                ? prefix + "(" + capture + ")?"
-                : "(?:" + prefix + "(" + capture + "))?"
-              : prefix + "(" + capture + ")");
-        }
+      })(a.key)
+    : b.toString(36);
+}
+function ea(a, b) {
+  a.func.call(a.context, b, a.count++);
+}
+function fa(a, b, d) {
+  var c = a.result,
+    e = a.keyPrefix;
+  (a = a.func.call(a.context, b, a.count++)),
+    Array.isArray(a)
+      ? V(a, c, d, function(a) {
+          return a;
+        })
+      : null != a &&
+        (N(a) &&
+          (a = (function(a, b) {
+            return {
+              $$typeof: p,
+              type: a.type,
+              key: b,
+              ref: a.ref,
+              props: a.props,
+              _owner: a._owner
+            };
+          })(
+            a,
+            e +
+              (!a.key || (b && b.key === a.key)
+                ? ""
+                : ("" + a.key).replace(O, "$&/") + "/") +
+              d
+          )),
+        c.push(a));
+}
+function V(a, b, d, c, e) {
+  var g = "";
+  null != d && (g = ("" + d).replace(O, "$&/") + "/"),
+    U(a, fa, (b = Q(b, g, c, e))),
+    R(b);
+}
+function W() {
+  var a = I.current;
+  return null === a && B("307"), a;
+}
+var X = {
+    Children: {
+      map: function(a, b, d) {
+        if (null == a) return a;
+        var c = [];
+        return V(a, c, null, b, d), c;
+      },
+      forEach: function(a, b, d) {
+        if (null == a) return a;
+        U(a, ea, (b = Q(null, null, b, d))), R(b);
+      },
+      count: function(a) {
+        return U(
+          a,
+          function() {
+            return null;
+          },
+          null
+        );
+      },
+      toArray: function(a) {
+        var b = [];
+        return (
+          V(a, b, null, function(a) {
+            return a;
+          }),
+          b
+        );
+      },
+      only: function(a) {
+        return N(a) || B("143"), a;
       }
-      var delimiter = escapeString(options.delimiter || "/"),
-        endsWithDelimiter = route.slice(-delimiter.length) === delimiter;
+    },
+    createRef: function() {
+      return { current: null };
+    },
+    Component: E,
+    PureComponent: G,
+    createContext: function(a, b) {
       return (
-        strict ||
-          (route =
-            (endsWithDelimiter ? route.slice(0, -delimiter.length) : route) +
-            "(?:" +
-            delimiter +
-            "(?=$))?"),
-        (route += end
-          ? "$"
-          : strict && endsWithDelimiter
-          ? ""
-          : "(?=" + delimiter + "|$)"),
-        attachKeys(new RegExp("^" + route, flags(options)), keys)
+        void 0 === b && (b = null),
+        ((a = {
+          $$typeof: w,
+          _calculateChangedBits: b,
+          _currentValue: a,
+          _currentValue2: a,
+          _threadCount: 0,
+          Provider: null,
+          Consumer: null
+        }).Provider = { $$typeof: v, _context: a }),
+        (a.Consumer = a)
       );
-    }
-    function pathToRegexp(path, keys, options) {
-      return (
-        isarray(keys) || ((options = keys || options), (keys = [])),
-        (options = options || {}),
-        path instanceof RegExp
-          ? (function(path, keys) {
-              var groups = path.source.match(/\((?!\?)/g);
-              if (groups)
-                for (var i = 0; i < groups.length; i++)
-                  keys.push({
-                    name: i,
-                    prefix: null,
-                    delimiter: null,
-                    optional: !1,
-                    repeat: !1,
-                    partial: !1,
-                    asterisk: !1,
-                    pattern: null
-                  });
-              return attachKeys(path, keys);
-            })(path, keys)
-          : isarray(path)
-          ? (function(path, keys, options) {
-              for (var parts = [], i = 0; i < path.length; i++)
-                parts.push(pathToRegexp(path[i], keys, options).source);
-              return attachKeys(
-                new RegExp("(?:" + parts.join("|") + ")", flags(options)),
-                keys
-              );
-            })(path, keys, options)
-          : (function(path, keys, options) {
-              return tokensToRegExp(parse(path, options), keys, options);
-            })(path, keys, options)
-      );
-    }
-  },
-  ,
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    module.exports = __webpack_require__(17);
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    exports.__esModule = !0;
-    var _react2 = _interopRequireDefault(__webpack_require__(0)),
-      _implementation2 = _interopRequireDefault(__webpack_require__(11));
-    function _interopRequireDefault(obj) {
-      return obj && obj.__esModule ? obj : { default: obj };
-    }
-    (exports.default =
-      _react2.default.createContext || _implementation2.default),
-      (module.exports = exports.default);
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    var ReactIs = __webpack_require__(4),
-      REACT_STATICS = {
-        childContextTypes: !0,
-        contextType: !0,
-        contextTypes: !0,
-        defaultProps: !0,
-        displayName: !0,
-        getDefaultProps: !0,
-        getDerivedStateFromError: !0,
-        getDerivedStateFromProps: !0,
-        mixins: !0,
-        propTypes: !0,
-        type: !0
-      },
-      KNOWN_STATICS = {
-        name: !0,
-        length: !0,
-        prototype: !0,
-        caller: !0,
-        callee: !0,
-        arguments: !0,
-        arity: !0
-      },
-      MEMO_STATICS = {
-        $$typeof: !0,
-        compare: !0,
-        defaultProps: !0,
-        displayName: !0,
-        propTypes: !0,
-        type: !0
-      },
-      TYPE_STATICS = {};
-    function getStatics(component) {
-      return ReactIs.isMemo(component)
-        ? MEMO_STATICS
-        : TYPE_STATICS[component.$$typeof] || REACT_STATICS;
-    }
-    TYPE_STATICS[ReactIs.ForwardRef] = {
-      $$typeof: !0,
-      render: !0,
-      defaultProps: !0,
-      displayName: !0,
-      propTypes: !0
-    };
-    var defineProperty = Object.defineProperty,
-      getOwnPropertyNames = Object.getOwnPropertyNames,
-      getOwnPropertySymbols = Object.getOwnPropertySymbols,
-      getOwnPropertyDescriptor = Object.getOwnPropertyDescriptor,
-      getPrototypeOf = Object.getPrototypeOf,
-      objectPrototype = Object.prototype;
-    module.exports = function hoistNonReactStatics(
-      targetComponent,
-      sourceComponent,
-      blacklist
-    ) {
-      if ("string" != typeof sourceComponent) {
-        if (objectPrototype) {
-          var inheritedComponent = getPrototypeOf(sourceComponent);
-          inheritedComponent &&
-            inheritedComponent !== objectPrototype &&
-            hoistNonReactStatics(
-              targetComponent,
-              inheritedComponent,
-              blacklist
-            );
-        }
-        var keys = getOwnPropertyNames(sourceComponent);
-        getOwnPropertySymbols &&
-          (keys = keys.concat(getOwnPropertySymbols(sourceComponent)));
-        for (
-          var targetStatics = getStatics(targetComponent),
-            sourceStatics = getStatics(sourceComponent),
-            i = 0;
-          i < keys.length;
-          ++i
-        ) {
-          var key = keys[i];
-          if (
-            !(
-              KNOWN_STATICS[key] ||
-              (blacklist && blacklist[key]) ||
-              (sourceStatics && sourceStatics[key]) ||
-              (targetStatics && targetStatics[key])
-            )
-          ) {
-            var descriptor = getOwnPropertyDescriptor(sourceComponent, key);
-            try {
-              defineProperty(targetComponent, key, descriptor);
-            } catch (e) {}
-          }
-        }
-        return targetComponent;
-      }
-      return targetComponent;
-    };
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    /** @license React v16.8.3
-     * react.production.min.js
-     *
-     * Copyright (c) Facebook, Inc. and its affiliates.
-     *
-     * This source code is licensed under the MIT license found in the
-     * LICENSE file in the root directory of this source tree.
-     */ var k = __webpack_require__(8),
-      n = "function" == typeof Symbol && Symbol.for,
-      p = n ? Symbol.for("react.element") : 60103,
-      q = n ? Symbol.for("react.portal") : 60106,
-      r = n ? Symbol.for("react.fragment") : 60107,
-      t = n ? Symbol.for("react.strict_mode") : 60108,
-      u = n ? Symbol.for("react.profiler") : 60114,
-      v = n ? Symbol.for("react.provider") : 60109,
-      w = n ? Symbol.for("react.context") : 60110,
-      x = n ? Symbol.for("react.concurrent_mode") : 60111,
-      y = n ? Symbol.for("react.forward_ref") : 60112,
-      z = n ? Symbol.for("react.suspense") : 60113,
-      aa = n ? Symbol.for("react.memo") : 60115,
-      ba = n ? Symbol.for("react.lazy") : 60116,
-      A = "function" == typeof Symbol && Symbol.iterator;
-    function B(a) {
-      for (
-        var b = arguments.length - 1,
-          d = "https://reactjs.org/docs/error-decoder.html?invariant=" + a,
-          c = 0;
-        c < b;
-        c++
-      )
-        d += "&args[]=" + encodeURIComponent(arguments[c + 1]);
-      !(function(a, b, d, c, e, g, h, f) {
-        if (!a) {
-          if (((a = void 0), void 0 === b))
-            a = Error(
-              "Minified exception occurred; use the non-minified dev environment for the full error message and additional helpful warnings."
-            );
-          else {
-            var l = [d, c, e, g, h, f],
-              m = 0;
-            (a = Error(
-              b.replace(/%s/g, function() {
-                return l[m++];
-              })
-            )).name = "Invariant Violation";
-          }
-          throw ((a.framesToPop = 1), a);
-        }
-      })(
-        !1,
-        "Minified React error #" +
-          a +
-          "; visit %s for the full message or use the non-minified dev environment for full errors and additional helpful warnings. ",
-        d
-      );
-    }
-    var C = {
-        isMounted: function() {
-          return !1;
-        },
-        enqueueForceUpdate: function() {},
-        enqueueReplaceState: function() {},
-        enqueueSetState: function() {}
-      },
-      D = {};
-    function E(a, b, d) {
-      (this.props = a),
-        (this.context = b),
-        (this.refs = D),
-        (this.updater = d || C);
-    }
-    function F() {}
-    function G(a, b, d) {
-      (this.props = a),
-        (this.context = b),
-        (this.refs = D),
-        (this.updater = d || C);
-    }
-    (E.prototype.isReactComponent = {}),
-      (E.prototype.setState = function(a, b) {
-        "object" != typeof a && "function" != typeof a && null != a && B("85"),
-          this.updater.enqueueSetState(this, a, b, "setState");
-      }),
-      (E.prototype.forceUpdate = function(a) {
-        this.updater.enqueueForceUpdate(this, a, "forceUpdate");
-      }),
-      (F.prototype = E.prototype);
-    var H = (G.prototype = new F());
-    (H.constructor = G), k(H, E.prototype), (H.isPureReactComponent = !0);
-    var I = { current: null },
-      J = { current: null },
-      K = Object.prototype.hasOwnProperty,
-      L = { key: !0, ref: !0, __self: !0, __source: !0 };
-    function M(a, b, d) {
+    },
+    forwardRef: function(a) {
+      return { $$typeof: y, render: a };
+    },
+    lazy: function(a) {
+      return { $$typeof: ba, _ctor: a, _status: -1, _result: null };
+    },
+    memo: function(a, b) {
+      return { $$typeof: aa, type: a, compare: void 0 === b ? null : b };
+    },
+    useCallback: function(a, b) {
+      return W().useCallback(a, b);
+    },
+    useContext: function(a, b) {
+      return W().useContext(a, b);
+    },
+    useEffect: function(a, b) {
+      return W().useEffect(a, b);
+    },
+    useImperativeHandle: function(a, b, d) {
+      return W().useImperativeHandle(a, b, d);
+    },
+    useDebugValue: function() {},
+    useLayoutEffect: function(a, b) {
+      return W().useLayoutEffect(a, b);
+    },
+    useMemo: function(a, b) {
+      return W().useMemo(a, b);
+    },
+    useReducer: function(a, b, d) {
+      return W().useReducer(a, b, d);
+    },
+    useRef: function(a) {
+      return W().useRef(a);
+    },
+    useState: function(a) {
+      return W().useState(a);
+    },
+    Fragment: r,
+    StrictMode: t,
+    Suspense: z,
+    createElement: M,
+    cloneElement: function(a, b, d) {
+      null == a && B("267", a);
       var c = void 0,
-        e = {},
-        g = null,
-        h = null;
-      if (null != b)
-        for (c in (void 0 !== b.ref && (h = b.ref),
-        void 0 !== b.key && (g = "" + b.key),
+        e = objectAssign({}, a.props),
+        g = a.key,
+        h = a.ref,
+        f = a._owner;
+      if (null != b) {
+        void 0 !== b.ref && ((h = b.ref), (f = J.current)),
+          void 0 !== b.key && (g = "" + b.key);
+        var l = void 0;
+        for (c in (a.type && a.type.defaultProps && (l = a.type.defaultProps),
         b))
-          K.call(b, c) && !L.hasOwnProperty(c) && (e[c] = b[c]);
-      var f = arguments.length - 2;
-      if (1 === f) e.children = d;
-      else if (1 < f) {
-        for (var l = Array(f), m = 0; m < f; m++) l[m] = arguments[m + 2];
+          K.call(b, c) &&
+            !L.hasOwnProperty(c) &&
+            (e[c] = void 0 === b[c] && void 0 !== l ? l[c] : b[c]);
+      }
+      if (1 === (c = arguments.length - 2)) e.children = d;
+      else if (1 < c) {
+        l = Array(c);
+        for (var m = 0; m < c; m++) l[m] = arguments[m + 2];
         e.children = l;
       }
-      if (a && a.defaultProps)
-        for (c in (f = a.defaultProps)) void 0 === e[c] && (e[c] = f[c]);
-      return {
-        $$typeof: p,
-        type: a,
-        key: g,
-        ref: h,
-        props: e,
-        _owner: J.current
-      };
+      return { $$typeof: p, type: a.type, key: g, ref: h, props: e, _owner: f };
+    },
+    createFactory: function(a) {
+      var b = M.bind(null, a);
+      return (b.type = a), b;
+    },
+    isValidElement: N,
+    version: "16.8.3",
+    unstable_ConcurrentMode: x,
+    unstable_Profiler: u,
+    __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
+      ReactCurrentDispatcher: I,
+      ReactCurrentOwner: J,
+      assign: objectAssign
     }
-    function N(a) {
-      return "object" == typeof a && null !== a && a.$$typeof === p;
-    }
-    var O = /\/+/g,
-      P = [];
-    function Q(a, b, d, c) {
-      if (P.length) {
-        var e = P.pop();
-        return (
-          (e.result = a),
-          (e.keyPrefix = b),
-          (e.func = d),
-          (e.context = c),
-          (e.count = 0),
-          e
-        );
-      }
-      return { result: a, keyPrefix: b, func: d, context: c, count: 0 };
-    }
-    function R(a) {
-      (a.result = null),
-        (a.keyPrefix = null),
-        (a.func = null),
-        (a.context = null),
-        (a.count = 0),
-        10 > P.length && P.push(a);
-    }
-    function U(a, b, d) {
-      return null == a
-        ? 0
-        : (function S(a, b, d, c) {
-            var e = typeof a;
-            ("undefined" !== e && "boolean" !== e) || (a = null);
-            var g = !1;
-            if (null === a) g = !0;
-            else
-              switch (e) {
-                case "string":
-                case "number":
-                  g = !0;
-                  break;
-                case "object":
-                  switch (a.$$typeof) {
-                    case p:
-                    case q:
-                      g = !0;
-                  }
-              }
-            if (g) return d(c, a, "" === b ? "." + T(a, 0) : b), 1;
-            if (((g = 0), (b = "" === b ? "." : b + ":"), Array.isArray(a)))
-              for (var h = 0; h < a.length; h++) {
-                var f = b + T((e = a[h]), h);
-                g += S(e, f, d, c);
-              }
-            else if (
-              ((f =
-                null === a || "object" != typeof a
-                  ? null
-                  : "function" == typeof (f = (A && a[A]) || a["@@iterator"])
-                  ? f
-                  : null),
-              "function" == typeof f)
-            )
-              for (a = f.call(a), h = 0; !(e = a.next()).done; )
-                g += S((e = e.value), (f = b + T(e, h++)), d, c);
-            else
-              "object" === e &&
-                B(
-                  "31",
-                  "[object Object]" == (d = "" + a)
-                    ? "object with keys {" + Object.keys(a).join(", ") + "}"
-                    : d,
-                  ""
-                );
-            return g;
-          })(a, "", b, d);
-    }
-    function T(a, b) {
-      return "object" == typeof a && null !== a && null != a.key
-        ? (function(a) {
-            var b = { "=": "=0", ":": "=2" };
-            return (
-              "$" +
-              ("" + a).replace(/[=:]/g, function(a) {
-                return b[a];
-              })
-            );
-          })(a.key)
-        : b.toString(36);
-    }
-    function ea(a, b) {
-      a.func.call(a.context, b, a.count++);
-    }
-    function fa(a, b, d) {
-      var c = a.result,
-        e = a.keyPrefix;
-      (a = a.func.call(a.context, b, a.count++)),
-        Array.isArray(a)
-          ? V(a, c, d, function(a) {
-              return a;
-            })
-          : null != a &&
-            (N(a) &&
-              (a = (function(a, b) {
-                return {
-                  $$typeof: p,
-                  type: a.type,
-                  key: b,
-                  ref: a.ref,
-                  props: a.props,
-                  _owner: a._owner
-                };
-              })(
-                a,
-                e +
-                  (!a.key || (b && b.key === a.key)
-                    ? ""
-                    : ("" + a.key).replace(O, "$&/") + "/") +
-                  d
-              )),
-            c.push(a));
-    }
-    function V(a, b, d, c, e) {
-      var g = "";
-      null != d && (g = ("" + d).replace(O, "$&/") + "/"),
-        U(a, fa, (b = Q(b, g, c, e))),
-        R(b);
-    }
-    function W() {
-      var a = I.current;
-      return null === a && B("307"), a;
-    }
-    var X = {
-        Children: {
-          map: function(a, b, d) {
-            if (null == a) return a;
-            var c = [];
-            return V(a, c, null, b, d), c;
-          },
-          forEach: function(a, b, d) {
-            if (null == a) return a;
-            U(a, ea, (b = Q(null, null, b, d))), R(b);
-          },
-          count: function(a) {
-            return U(
-              a,
-              function() {
-                return null;
-              },
-              null
-            );
-          },
-          toArray: function(a) {
-            var b = [];
-            return (
-              V(a, b, null, function(a) {
-                return a;
-              }),
-              b
-            );
-          },
-          only: function(a) {
-            return N(a) || B("143"), a;
-          }
-        },
-        createRef: function() {
-          return { current: null };
-        },
-        Component: E,
-        PureComponent: G,
-        createContext: function(a, b) {
-          return (
-            void 0 === b && (b = null),
-            ((a = {
-              $$typeof: w,
-              _calculateChangedBits: b,
-              _currentValue: a,
-              _currentValue2: a,
-              _threadCount: 0,
-              Provider: null,
-              Consumer: null
-            }).Provider = { $$typeof: v, _context: a }),
-            (a.Consumer = a)
-          );
-        },
-        forwardRef: function(a) {
-          return { $$typeof: y, render: a };
-        },
-        lazy: function(a) {
-          return { $$typeof: ba, _ctor: a, _status: -1, _result: null };
-        },
-        memo: function(a, b) {
-          return { $$typeof: aa, type: a, compare: void 0 === b ? null : b };
-        },
-        useCallback: function(a, b) {
-          return W().useCallback(a, b);
-        },
-        useContext: function(a, b) {
-          return W().useContext(a, b);
-        },
-        useEffect: function(a, b) {
-          return W().useEffect(a, b);
-        },
-        useImperativeHandle: function(a, b, d) {
-          return W().useImperativeHandle(a, b, d);
-        },
-        useDebugValue: function() {},
-        useLayoutEffect: function(a, b) {
-          return W().useLayoutEffect(a, b);
-        },
-        useMemo: function(a, b) {
-          return W().useMemo(a, b);
-        },
-        useReducer: function(a, b, d) {
-          return W().useReducer(a, b, d);
-        },
-        useRef: function(a) {
-          return W().useRef(a);
-        },
-        useState: function(a) {
-          return W().useState(a);
-        },
-        Fragment: r,
-        StrictMode: t,
-        Suspense: z,
-        createElement: M,
-        cloneElement: function(a, b, d) {
-          null == a && B("267", a);
-          var c = void 0,
-            e = k({}, a.props),
-            g = a.key,
-            h = a.ref,
-            f = a._owner;
-          if (null != b) {
-            void 0 !== b.ref && ((h = b.ref), (f = J.current)),
-              void 0 !== b.key && (g = "" + b.key);
-            var l = void 0;
-            for (c in (a.type &&
-              a.type.defaultProps &&
-              (l = a.type.defaultProps),
-            b))
-              K.call(b, c) &&
-                !L.hasOwnProperty(c) &&
-                (e[c] = void 0 === b[c] && void 0 !== l ? l[c] : b[c]);
-          }
-          if (1 === (c = arguments.length - 2)) e.children = d;
-          else if (1 < c) {
-            l = Array(c);
-            for (var m = 0; m < c; m++) l[m] = arguments[m + 2];
-            e.children = l;
-          }
-          return {
-            $$typeof: p,
-            type: a.type,
-            key: g,
-            ref: h,
-            props: e,
-            _owner: f
-          };
-        },
-        createFactory: function(a) {
-          var b = M.bind(null, a);
-          return (b.type = a), b;
-        },
-        isValidElement: N,
-        version: "16.8.3",
-        unstable_ConcurrentMode: x,
-        unstable_Profiler: u,
-        __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: {
-          ReactCurrentDispatcher: I,
-          ReactCurrentOwner: J,
-          assign: k
-        }
-      },
-      Y = { default: X },
-      Z = (Y && X) || Y;
-    module.exports = Z.default || Z;
   },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    /*
-object-assign
-(c) Sindre Sorhus
-@license MIT
-*/ var getOwnPropertySymbols =
-        Object.getOwnPropertySymbols,
-      hasOwnProperty = Object.prototype.hasOwnProperty,
-      propIsEnumerable = Object.prototype.propertyIsEnumerable;
+  Y = { default: X },
+  Z = (Y && X) || Y,
+  react_production_min = Z.default || Z,
+  ReactPropTypesSecret_1 = "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED",
+  react = (createCommonjsModule(function(module) {}),
+  createCommonjsModule(function(module) {
+    module.exports = react_production_min;
+  }));
+Function.call.bind(Object.prototype.hasOwnProperty);
+function emptyFunction() {}
+function emptyFunctionWithReset() {}
+emptyFunctionWithReset.resetWarningCache = emptyFunction;
+var propTypes = createCommonjsModule(function(module) {
     module.exports = (function() {
-      try {
-        if (!Object.assign) return !1;
-        var test1 = new String("abc");
-        if (((test1[5] = "de"), "5" === Object.getOwnPropertyNames(test1)[0]))
-          return !1;
-        for (var test2 = {}, i = 0; i < 10; i++)
-          test2["_" + String.fromCharCode(i)] = i;
-        if (
-          "0123456789" !==
-          Object.getOwnPropertyNames(test2)
-            .map(function(n) {
-              return test2[n];
-            })
-            .join("")
-        )
-          return !1;
-        var test3 = {};
-        return (
-          "abcdefghijklmnopqrst".split("").forEach(function(letter) {
-            test3[letter] = letter;
-          }),
-          "abcdefghijklmnopqrst" ===
-            Object.keys(Object.assign({}, test3)).join("")
-        );
-      } catch (err) {
-        return !1;
+      function shim(
+        props,
+        propName,
+        componentName,
+        location,
+        propFullName,
+        secret
+      ) {
+        if (secret !== ReactPropTypesSecret_1) {
+          var err = new Error(
+            "Calling PropTypes validators directly is not supported by the `prop-types` package. Use PropTypes.checkPropTypes() to call them. Read more at http://fb.me/use-check-prop-types"
+          );
+          throw ((err.name = "Invariant Violation"), err);
+        }
       }
-    })()
-      ? Object.assign
-      : function(target, source) {
-          for (
-            var from,
-              symbols,
-              to = (function(val) {
-                if (null == val)
-                  throw new TypeError(
-                    "Object.assign cannot be called with null or undefined"
-                  );
-                return Object(val);
-              })(target),
-              s = 1;
-            s < arguments.length;
-            s++
-          ) {
-            for (var key in (from = Object(arguments[s])))
-              hasOwnProperty.call(from, key) && (to[key] = from[key]);
-            if (getOwnPropertySymbols) {
-              symbols = getOwnPropertySymbols(from);
-              for (var i = 0; i < symbols.length; i++)
-                propIsEnumerable.call(from, symbols[i]) &&
-                  (to[symbols[i]] = from[symbols[i]]);
-            }
-          }
-          return to;
-        };
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    var ReactPropTypesSecret = __webpack_require__(10);
-    function emptyFunction() {}
-    function emptyFunctionWithReset() {}
-    (emptyFunctionWithReset.resetWarningCache = emptyFunction),
-      (module.exports = function() {
-        function shim(
-          props,
-          propName,
-          componentName,
-          location,
-          propFullName,
-          secret
-        ) {
-          if (secret !== ReactPropTypesSecret) {
-            var err = new Error(
-              "Calling PropTypes validators directly is not supported by the `prop-types` package. Use PropTypes.checkPropTypes() to call them. Read more at http://fb.me/use-check-prop-types"
-            );
-            throw ((err.name = "Invariant Violation"), err);
-          }
-        }
-        function getShim() {
-          return shim;
-        }
-        shim.isRequired = shim;
-        var ReactPropTypes = {
-          array: shim,
-          bool: shim,
-          func: shim,
-          number: shim,
-          object: shim,
-          string: shim,
-          symbol: shim,
-          any: shim,
-          arrayOf: getShim,
-          element: shim,
-          elementType: shim,
-          instanceOf: getShim,
-          node: shim,
-          objectOf: getShim,
-          oneOf: getShim,
-          oneOfType: getShim,
-          shape: getShim,
-          exact: getShim,
-          checkPropTypes: emptyFunctionWithReset,
-          resetWarningCache: emptyFunction
-        };
-        return (ReactPropTypes.PropTypes = ReactPropTypes), ReactPropTypes;
-      });
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    module.exports = "SECRET_DO_NOT_PASS_THIS_OR_YOU_WILL_BE_FIRED";
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
+      function getShim() {
+        return shim;
+      }
+      shim.isRequired = shim;
+      var ReactPropTypes = {
+        array: shim,
+        bool: shim,
+        func: shim,
+        number: shim,
+        object: shim,
+        string: shim,
+        symbol: shim,
+        any: shim,
+        arrayOf: getShim,
+        element: shim,
+        elementType: shim,
+        instanceOf: getShim,
+        node: shim,
+        objectOf: getShim,
+        oneOf: getShim,
+        oneOfType: getShim,
+        shape: getShim,
+        exact: getShim,
+        checkPropTypes: emptyFunctionWithReset,
+        resetWarningCache: emptyFunction
+      };
+      return (ReactPropTypes.PropTypes = ReactPropTypes), ReactPropTypes;
+    })();
+  }),
+  key = "__global_unique_id__",
+  gud = function() {
+    return (commonjsGlobal[key] = (commonjsGlobal[key] || 0) + 1);
+  };
+function makeEmptyFunction(arg) {
+  return function() {
+    return arg;
+  };
+}
+var emptyFunction$1 = function() {};
+(emptyFunction$1.thatReturns = makeEmptyFunction),
+  (emptyFunction$1.thatReturnsFalse = makeEmptyFunction(!1)),
+  (emptyFunction$1.thatReturnsTrue = makeEmptyFunction(!0)),
+  (emptyFunction$1.thatReturnsNull = makeEmptyFunction(null)),
+  (emptyFunction$1.thatReturnsThis = function() {
+    return this;
+  }),
+  (emptyFunction$1.thatReturnsArgument = function(arg) {
+    return arg;
+  });
+var warning_1 = emptyFunction$1,
+  implementation = createCommonjsModule(function(module, exports) {
     exports.__esModule = !0;
-    var _react = __webpack_require__(0),
-      _propTypes2 = (_interopRequireDefault(_react),
-      _interopRequireDefault(__webpack_require__(1))),
-      _gud2 = _interopRequireDefault(__webpack_require__(12));
-    _interopRequireDefault(__webpack_require__(14));
+    _interopRequireDefault(react);
+    var _propTypes2 = _interopRequireDefault(propTypes),
+      _gud2 = _interopRequireDefault(gud);
+    _interopRequireDefault(warning_1);
     function _interopRequireDefault(obj) {
       return obj && obj.__esModule ? obj : { default: obj };
     }
@@ -1093,7 +646,7 @@ object-assign
             }),
             Provider
           );
-        })(_react.Component);
+        })(react.Component);
       Provider.childContextTypes = (((_Provider$childContex = {})[contextProp] =
         _propTypes2.default.object.isRequired),
       _Provider$childContex);
@@ -1150,7 +703,7 @@ object-assign
           }),
           Consumer
         );
-      })(_react.Component);
+      })(react.Component);
       return (
         (Consumer.contextTypes = (((_Consumer$contextType = {})[contextProp] =
           _propTypes2.default.object),
@@ -1159,1094 +712,1133 @@ object-assign
       );
     }),
       (module.exports = exports.default);
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    (function(global) {
-      var key = "__global_unique_id__";
-      module.exports = function() {
-        return (global[key] = (global[key] || 0) + 1);
-      };
-    }.call(this, __webpack_require__(13)));
-  },
-  function(module, exports) {
-    var g;
-    g = (function() {
-      return this;
-    })();
-    try {
-      g = g || new Function("return this")();
-    } catch (e) {
-      "object" == typeof window && (g = window);
+  });
+unwrapExports(implementation);
+var createContext = unwrapExports(
+  createCommonjsModule(function(module, exports) {
+    exports.__esModule = !0;
+    var _react2 = _interopRequireDefault(react),
+      _implementation2 = _interopRequireDefault(implementation);
+    function _interopRequireDefault(obj) {
+      return obj && obj.__esModule ? obj : { default: obj };
     }
-    module.exports = g;
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    var warning = __webpack_require__(15);
-    module.exports = warning;
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    function makeEmptyFunction(arg) {
-      return function() {
-        return arg;
-      };
-    }
-    var emptyFunction = function() {};
-    (emptyFunction.thatReturns = makeEmptyFunction),
-      (emptyFunction.thatReturnsFalse = makeEmptyFunction(!1)),
-      (emptyFunction.thatReturnsTrue = makeEmptyFunction(!0)),
-      (emptyFunction.thatReturnsNull = makeEmptyFunction(null)),
-      (emptyFunction.thatReturnsThis = function() {
-        return this;
-      }),
-      (emptyFunction.thatReturnsArgument = function(arg) {
-        return arg;
-      }),
-      (module.exports = emptyFunction);
-  },
-  function(module, exports) {
-    module.exports =
-      Array.isArray ||
-      function(arr) {
-        return "[object Array]" == Object.prototype.toString.call(arr);
-      };
-  },
-  function(module, exports, __webpack_require__) {
-    "use strict";
-    /** @license React v16.8.3
-     * react-is.production.min.js
-     *
-     * Copyright (c) Facebook, Inc. and its affiliates.
-     *
-     * This source code is licensed under the MIT license found in the
-     * LICENSE file in the root directory of this source tree.
-     */ Object.defineProperty(exports, "__esModule", { value: !0 });
-    var b = "function" == typeof Symbol && Symbol.for,
-      c = b ? Symbol.for("react.element") : 60103,
-      d = b ? Symbol.for("react.portal") : 60106,
-      e = b ? Symbol.for("react.fragment") : 60107,
-      f = b ? Symbol.for("react.strict_mode") : 60108,
-      g = b ? Symbol.for("react.profiler") : 60114,
-      h = b ? Symbol.for("react.provider") : 60109,
-      k = b ? Symbol.for("react.context") : 60110,
-      l = b ? Symbol.for("react.async_mode") : 60111,
-      m = b ? Symbol.for("react.concurrent_mode") : 60111,
-      n = b ? Symbol.for("react.forward_ref") : 60112,
-      p = b ? Symbol.for("react.suspense") : 60113,
-      q = b ? Symbol.for("react.memo") : 60115,
-      r = b ? Symbol.for("react.lazy") : 60116;
-    function t(a) {
-      if ("object" == typeof a && null !== a) {
-        var u = a.$$typeof;
-        switch (u) {
-          case c:
-            switch ((a = a.type)) {
-              case l:
-              case m:
-              case e:
-              case g:
-              case f:
-              case p:
-                return a;
-              default:
-                switch ((a = a && a.$$typeof)) {
-                  case k:
-                  case n:
-                  case h:
-                    return a;
-                  default:
-                    return u;
-                }
-            }
-          case r:
-          case q:
-          case d:
-            return u;
-        }
+    (exports.default =
+      _react2.default.createContext || _implementation2.default),
+      (module.exports = exports.default);
+  })
+);
+function _extends() {
+  return (_extends =
+    Object.assign ||
+    function(target) {
+      for (var i = 1; i < arguments.length; i++) {
+        var source = arguments[i];
+        for (var key in source)
+          Object.prototype.hasOwnProperty.call(source, key) &&
+            (target[key] = source[key]);
       }
-    }
-    function v(a) {
-      return t(a) === m;
-    }
-    (exports.typeOf = t),
-      (exports.AsyncMode = l),
-      (exports.ConcurrentMode = m),
-      (exports.ContextConsumer = k),
-      (exports.ContextProvider = h),
-      (exports.Element = c),
-      (exports.ForwardRef = n),
-      (exports.Fragment = e),
-      (exports.Lazy = r),
-      (exports.Memo = q),
-      (exports.Portal = d),
-      (exports.Profiler = g),
-      (exports.StrictMode = f),
-      (exports.Suspense = p),
-      (exports.isValidElementType = function(a) {
-        return (
-          "string" == typeof a ||
-          "function" == typeof a ||
-          a === e ||
-          a === m ||
-          a === g ||
-          a === f ||
-          a === p ||
-          ("object" == typeof a &&
-            null !== a &&
-            (a.$$typeof === r ||
-              a.$$typeof === q ||
-              a.$$typeof === h ||
-              a.$$typeof === k ||
-              a.$$typeof === n))
-        );
-      }),
-      (exports.isAsyncMode = function(a) {
-        return v(a) || t(a) === l;
-      }),
-      (exports.isConcurrentMode = v),
-      (exports.isContextConsumer = function(a) {
-        return t(a) === k;
-      }),
-      (exports.isContextProvider = function(a) {
-        return t(a) === h;
-      }),
-      (exports.isElement = function(a) {
-        return "object" == typeof a && null !== a && a.$$typeof === c;
-      }),
-      (exports.isForwardRef = function(a) {
-        return t(a) === n;
-      }),
-      (exports.isFragment = function(a) {
-        return t(a) === e;
-      }),
-      (exports.isLazy = function(a) {
-        return t(a) === r;
-      }),
-      (exports.isMemo = function(a) {
-        return t(a) === q;
-      }),
-      (exports.isPortal = function(a) {
-        return t(a) === d;
-      }),
-      (exports.isProfiler = function(a) {
-        return t(a) === g;
-      }),
-      (exports.isStrictMode = function(a) {
-        return t(a) === f;
-      }),
-      (exports.isSuspense = function(a) {
-        return t(a) === p;
-      });
-  },
-  function(module, __webpack_exports__, __webpack_require__) {
-    "use strict";
-    function _inheritsLoose(subClass, superClass) {
-      (subClass.prototype = Object.create(superClass.prototype)),
-        (subClass.prototype.constructor = subClass),
-        (subClass.__proto__ = superClass);
-    }
-    __webpack_require__.r(__webpack_exports__);
-    var react = __webpack_require__(0),
-      react_default = __webpack_require__.n(react),
-      lib = __webpack_require__(5),
-      lib_default = __webpack_require__.n(lib);
-    __webpack_require__(1);
-    function _extends() {
-      return (_extends =
-        Object.assign ||
-        function(target) {
-          for (var i = 1; i < arguments.length; i++) {
-            var source = arguments[i];
-            for (var key in source)
-              Object.prototype.hasOwnProperty.call(source, key) &&
-                (target[key] = source[key]);
-          }
-          return target;
-        }).apply(this, arguments);
-    }
-    function isAbsolute(pathname) {
-      return "/" === pathname.charAt(0);
-    }
-    function spliceOne(list, index) {
-      for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
-        list[i] = list[k];
-      list.pop();
-    }
-    var resolve_pathname = function(to) {
-        var from =
-            arguments.length > 1 && void 0 !== arguments[1] ? arguments[1] : "",
-          toParts = (to && to.split("/")) || [],
-          fromParts = (from && from.split("/")) || [],
-          isToAbs = to && isAbsolute(to),
-          isFromAbs = from && isAbsolute(from),
-          mustEndAbs = isToAbs || isFromAbs;
-        if (
-          (to && isAbsolute(to)
-            ? (fromParts = toParts)
-            : toParts.length &&
-              (fromParts.pop(), (fromParts = fromParts.concat(toParts))),
-          !fromParts.length)
-        )
-          return "/";
-        var hasTrailingSlash = void 0;
-        if (fromParts.length) {
-          var last = fromParts[fromParts.length - 1];
-          hasTrailingSlash = "." === last || ".." === last || "" === last;
-        } else hasTrailingSlash = !1;
-        for (var up = 0, i = fromParts.length; i >= 0; i--) {
-          var part = fromParts[i];
-          "." === part
-            ? spliceOne(fromParts, i)
-            : ".." === part
-            ? (spliceOne(fromParts, i), up++)
-            : up && (spliceOne(fromParts, i), up--);
-        }
-        if (!mustEndAbs) for (; up--; up) fromParts.unshift("..");
-        !mustEndAbs ||
-          "" === fromParts[0] ||
-          (fromParts[0] && isAbsolute(fromParts[0])) ||
-          fromParts.unshift("");
-        var result = fromParts.join("/");
-        return (
-          hasTrailingSlash && "/" !== result.substr(-1) && (result += "/"),
-          result
-        );
-      },
-      _typeof =
-        "function" == typeof Symbol && "symbol" == typeof Symbol.iterator
-          ? function(obj) {
-              return typeof obj;
-            }
-          : function(obj) {
-              return obj &&
-                "function" == typeof Symbol &&
-                obj.constructor === Symbol &&
-                obj !== Symbol.prototype
-                ? "symbol"
-                : typeof obj;
-            };
-    var value_equal = function valueEqual(a, b) {
-        if (a === b) return !0;
-        if (null == a || null == b) return !1;
-        if (Array.isArray(a))
-          return (
-            Array.isArray(b) &&
-            a.length === b.length &&
-            a.every(function(item, index) {
-              return valueEqual(item, b[index]);
-            })
-          );
-        var aType = void 0 === a ? "undefined" : _typeof(a);
-        if (aType !== (void 0 === b ? "undefined" : _typeof(b))) return !1;
-        if ("object" === aType) {
-          var aValue = a.valueOf(),
-            bValue = b.valueOf();
-          if (aValue !== a || bValue !== b) return valueEqual(aValue, bValue);
-          var aKeys = Object.keys(a),
-            bKeys = Object.keys(b);
-          return (
-            aKeys.length === bKeys.length &&
-            aKeys.every(function(key) {
-              return valueEqual(a[key], b[key]);
-            })
-          );
-        }
-        return !1;
-      },
-      isProduction = !0,
-      prefix = "Invariant failed";
-    var tiny_invariant_esm = function(condition, message) {
-      if (!condition)
-        throw isProduction
-          ? new Error(prefix)
-          : new Error(prefix + ": " + (message || ""));
-    };
-    function addLeadingSlash(path) {
-      return "/" === path.charAt(0) ? path : "/" + path;
-    }
-    function stripLeadingSlash(path) {
-      return "/" === path.charAt(0) ? path.substr(1) : path;
-    }
-    function stripBasename(path, prefix) {
-      return (function(path, prefix) {
-        return new RegExp("^" + prefix + "(\\/|\\?|#|$)", "i").test(path);
-      })(path, prefix)
-        ? path.substr(prefix.length)
-        : path;
-    }
-    function stripTrailingSlash(path) {
-      return "/" === path.charAt(path.length - 1) ? path.slice(0, -1) : path;
-    }
-    function createPath(location) {
-      var pathname = location.pathname,
-        search = location.search,
-        hash = location.hash,
-        path = pathname || "/";
-      return (
-        search &&
-          "?" !== search &&
-          (path += "?" === search.charAt(0) ? search : "?" + search),
-        hash &&
-          "#" !== hash &&
-          (path += "#" === hash.charAt(0) ? hash : "#" + hash),
-        path
-      );
-    }
-    function createLocation(path, state, key, currentLocation) {
-      var location;
-      "string" == typeof path
-        ? ((location = (function(path) {
-            var pathname = path || "/",
-              search = "",
-              hash = "",
-              hashIndex = pathname.indexOf("#");
-            -1 !== hashIndex &&
-              ((hash = pathname.substr(hashIndex)),
-              (pathname = pathname.substr(0, hashIndex)));
-            var searchIndex = pathname.indexOf("?");
-            return (
-              -1 !== searchIndex &&
-                ((search = pathname.substr(searchIndex)),
-                (pathname = pathname.substr(0, searchIndex))),
-              {
-                pathname: pathname,
-                search: "?" === search ? "" : search,
-                hash: "#" === hash ? "" : hash
-              }
-            );
-          })(path)).state = state)
-        : (void 0 === (location = _extends({}, path)).pathname &&
-            (location.pathname = ""),
-          location.search
-            ? "?" !== location.search.charAt(0) &&
-              (location.search = "?" + location.search)
-            : (location.search = ""),
-          location.hash
-            ? "#" !== location.hash.charAt(0) &&
-              (location.hash = "#" + location.hash)
-            : (location.hash = ""),
-          void 0 !== state &&
-            void 0 === location.state &&
-            (location.state = state));
-      try {
-        location.pathname = decodeURI(location.pathname);
-      } catch (e) {
-        throw e instanceof URIError
-          ? new URIError(
-              'Pathname "' +
-                location.pathname +
-                '" could not be decoded. This is likely caused by an invalid percent-encoding.'
-            )
-          : e;
-      }
-      return (
-        key && (location.key = key),
-        currentLocation
-          ? location.pathname
-            ? "/" !== location.pathname.charAt(0) &&
-              (location.pathname = resolve_pathname(
-                location.pathname,
-                currentLocation.pathname
-              ))
-            : (location.pathname = currentLocation.pathname)
-          : location.pathname || (location.pathname = "/"),
-        location
-      );
-    }
-    function locationsAreEqual(a, b) {
-      return (
-        a.pathname === b.pathname &&
-        a.search === b.search &&
-        a.hash === b.hash &&
-        a.key === b.key &&
-        value_equal(a.state, b.state)
-      );
-    }
-    function createTransitionManager() {
-      var prompt = null;
-      var listeners = [];
-      return {
-        setPrompt: function(nextPrompt) {
-          return (
-            (prompt = nextPrompt),
-            function() {
-              prompt === nextPrompt && (prompt = null);
-            }
-          );
-        },
-        confirmTransitionTo: function(
-          location,
-          action,
-          getUserConfirmation,
-          callback
-        ) {
-          if (null != prompt) {
-            var result =
-              "function" == typeof prompt ? prompt(location, action) : prompt;
-            "string" == typeof result
-              ? "function" == typeof getUserConfirmation
-                ? getUserConfirmation(result, callback)
-                : callback(!0)
-              : callback(!1 !== result);
-          } else callback(!0);
-        },
-        appendListener: function(fn) {
-          var isActive = !0;
-          function listener() {
-            isActive && fn.apply(void 0, arguments);
-          }
-          return (
-            listeners.push(listener),
-            function() {
-              (isActive = !1),
-                (listeners = listeners.filter(function(item) {
-                  return item !== listener;
-                }));
-            }
-          );
-        },
-        notifyListeners: function() {
-          for (
-            var _len = arguments.length, args = new Array(_len), _key = 0;
-            _key < _len;
-            _key++
-          )
-            args[_key] = arguments[_key];
-          listeners.forEach(function(listener) {
-            return listener.apply(void 0, args);
-          });
-        }
-      };
-    }
-    var canUseDOM = !(
-      "undefined" == typeof window ||
-      !window.document ||
-      !window.document.createElement
-    );
-    function getConfirmation(message, callback) {
-      callback(window.confirm(message));
-    }
-    var PopStateEvent = "popstate",
-      HashChangeEvent = "hashchange";
-    function getHistoryState() {
-      try {
-        return window.history.state || {};
-      } catch (e) {
-        return {};
-      }
-    }
-    function createBrowserHistory(props) {
-      void 0 === props && (props = {}), canUseDOM || tiny_invariant_esm(!1);
-      var ua,
-        globalHistory = window.history,
-        canUseHistory =
-          ((-1 === (ua = window.navigator.userAgent).indexOf("Android 2.") &&
-            -1 === ua.indexOf("Android 4.0")) ||
-            -1 === ua.indexOf("Mobile Safari") ||
-            -1 !== ua.indexOf("Chrome") ||
-            -1 !== ua.indexOf("Windows Phone")) &&
-          window.history &&
-          "pushState" in window.history,
-        needsHashChangeListener = !(
-          -1 === window.navigator.userAgent.indexOf("Trident")
-        ),
-        _props = props,
-        _props$forceRefresh = _props.forceRefresh,
-        forceRefresh = void 0 !== _props$forceRefresh && _props$forceRefresh,
-        _props$getUserConfirm = _props.getUserConfirmation,
-        getUserConfirmation =
-          void 0 === _props$getUserConfirm
-            ? getConfirmation
-            : _props$getUserConfirm,
-        _props$keyLength = _props.keyLength,
-        keyLength = void 0 === _props$keyLength ? 6 : _props$keyLength,
-        basename = props.basename
-          ? stripTrailingSlash(addLeadingSlash(props.basename))
-          : "";
-      function getDOMLocation(historyState) {
-        var _ref = historyState || {},
-          key = _ref.key,
-          state = _ref.state,
-          _window$location = window.location,
-          path =
-            _window$location.pathname +
-            _window$location.search +
-            _window$location.hash;
-        return (
-          basename && (path = stripBasename(path, basename)),
-          createLocation(path, state, key)
-        );
-      }
-      function createKey() {
-        return Math.random()
-          .toString(36)
-          .substr(2, keyLength);
-      }
-      var transitionManager = createTransitionManager();
-      function setState(nextState) {
-        _extends(history, nextState),
-          (history.length = globalHistory.length),
-          transitionManager.notifyListeners(history.location, history.action);
-      }
-      function handlePopState(event) {
-        (function(event) {
-          void 0 === event.state && navigator.userAgent.indexOf("CriOS");
-        })(event) || handlePop(getDOMLocation(event.state));
-      }
-      function handleHashChange() {
-        handlePop(getDOMLocation(getHistoryState()));
-      }
-      var forceNextPop = !1;
-      function handlePop(location) {
-        if (forceNextPop) (forceNextPop = !1), setState();
-        else {
-          transitionManager.confirmTransitionTo(
-            location,
-            "POP",
-            getUserConfirmation,
-            function(ok) {
-              ok
-                ? setState({ action: "POP", location: location })
-                : (function(fromLocation) {
-                    var toLocation = history.location,
-                      toIndex = allKeys.indexOf(toLocation.key);
-                    -1 === toIndex && (toIndex = 0);
-                    var fromIndex = allKeys.indexOf(fromLocation.key);
-                    -1 === fromIndex && (fromIndex = 0);
-                    var delta = toIndex - fromIndex;
-                    delta && ((forceNextPop = !0), go(delta));
-                  })(location);
-            }
-          );
-        }
-      }
-      var initialLocation = getDOMLocation(getHistoryState()),
-        allKeys = [initialLocation.key];
-      function createHref(location) {
-        return basename + createPath(location);
-      }
-      function go(n) {
-        globalHistory.go(n);
-      }
-      var listenerCount = 0;
-      function checkDOMListeners(delta) {
-        1 === (listenerCount += delta)
-          ? (window.addEventListener(PopStateEvent, handlePopState),
-            needsHashChangeListener &&
-              window.addEventListener(HashChangeEvent, handleHashChange))
-          : 0 === listenerCount &&
-            (window.removeEventListener(PopStateEvent, handlePopState),
-            needsHashChangeListener &&
-              window.removeEventListener(HashChangeEvent, handleHashChange));
-      }
-      var isBlocked = !1;
-      var history = {
-        length: globalHistory.length,
-        action: "POP",
-        location: initialLocation,
-        createHref: createHref,
-        push: function(path, state) {
-          var location = createLocation(
-            path,
-            state,
-            createKey(),
-            history.location
-          );
-          transitionManager.confirmTransitionTo(
-            location,
-            "PUSH",
-            getUserConfirmation,
-            function(ok) {
-              if (ok) {
-                var href = createHref(location),
-                  key = location.key,
-                  state = location.state;
-                if (canUseHistory)
-                  if (
-                    (globalHistory.pushState(
-                      { key: key, state: state },
-                      null,
-                      href
-                    ),
-                    forceRefresh)
-                  )
-                    window.location.href = href;
-                  else {
-                    var prevIndex = allKeys.indexOf(history.location.key),
-                      nextKeys = allKeys.slice(
-                        0,
-                        -1 === prevIndex ? 0 : prevIndex + 1
-                      );
-                    nextKeys.push(location.key),
-                      (allKeys = nextKeys),
-                      setState({ action: "PUSH", location: location });
-                  }
-                else window.location.href = href;
-              }
-            }
-          );
-        },
-        replace: function(path, state) {
-          var location = createLocation(
-            path,
-            state,
-            createKey(),
-            history.location
-          );
-          transitionManager.confirmTransitionTo(
-            location,
-            "REPLACE",
-            getUserConfirmation,
-            function(ok) {
-              if (ok) {
-                var href = createHref(location),
-                  key = location.key,
-                  state = location.state;
-                if (canUseHistory)
-                  if (
-                    (globalHistory.replaceState(
-                      { key: key, state: state },
-                      null,
-                      href
-                    ),
-                    forceRefresh)
-                  )
-                    window.location.replace(href);
-                  else {
-                    var prevIndex = allKeys.indexOf(history.location.key);
-                    -1 !== prevIndex && (allKeys[prevIndex] = location.key),
-                      setState({ action: "REPLACE", location: location });
-                  }
-                else window.location.replace(href);
-              }
-            }
-          );
-        },
-        go: go,
-        goBack: function() {
-          go(-1);
-        },
-        goForward: function() {
-          go(1);
-        },
-        block: function(prompt) {
-          void 0 === prompt && (prompt = !1);
-          var unblock = transitionManager.setPrompt(prompt);
-          return (
-            isBlocked || (checkDOMListeners(1), (isBlocked = !0)),
-            function() {
-              return (
-                isBlocked && ((isBlocked = !1), checkDOMListeners(-1)),
-                unblock()
-              );
-            }
-          );
-        },
-        listen: function(listener) {
-          var unlisten = transitionManager.appendListener(listener);
-          return (
-            checkDOMListeners(1),
-            function() {
-              checkDOMListeners(-1), unlisten();
-            }
-          );
-        }
-      };
-      return history;
-    }
-    var HashChangeEvent$1 = "hashchange",
-      HashPathCoders = {
-        hashbang: {
-          encodePath: function(path) {
-            return "!" === path.charAt(0)
-              ? path
-              : "!/" + stripLeadingSlash(path);
-          },
-          decodePath: function(path) {
-            return "!" === path.charAt(0) ? path.substr(1) : path;
-          }
-        },
-        noslash: { encodePath: stripLeadingSlash, decodePath: addLeadingSlash },
-        slash: { encodePath: addLeadingSlash, decodePath: addLeadingSlash }
-      };
-    function getHashPath() {
-      var href = window.location.href,
-        hashIndex = href.indexOf("#");
-      return -1 === hashIndex ? "" : href.substring(hashIndex + 1);
-    }
-    function replaceHashPath(path) {
-      var hashIndex = window.location.href.indexOf("#");
-      window.location.replace(
-        window.location.href.slice(0, hashIndex >= 0 ? hashIndex : 0) +
-          "#" +
-          path
-      );
-    }
-    function createHashHistory(props) {
-      void 0 === props && (props = {}), canUseDOM || tiny_invariant_esm(!1);
-      var globalHistory = window.history,
-        _props = (window.navigator.userAgent.indexOf("Firefox"), props),
-        _props$getUserConfirm = _props.getUserConfirmation,
-        getUserConfirmation =
-          void 0 === _props$getUserConfirm
-            ? getConfirmation
-            : _props$getUserConfirm,
-        _props$hashType = _props.hashType,
-        hashType = void 0 === _props$hashType ? "slash" : _props$hashType,
-        basename = props.basename
-          ? stripTrailingSlash(addLeadingSlash(props.basename))
-          : "",
-        _HashPathCoders$hashT = HashPathCoders[hashType],
-        encodePath = _HashPathCoders$hashT.encodePath,
-        decodePath = _HashPathCoders$hashT.decodePath;
-      function getDOMLocation() {
-        var path = decodePath(getHashPath());
-        return (
-          basename && (path = stripBasename(path, basename)),
-          createLocation(path)
-        );
-      }
-      var transitionManager = createTransitionManager();
-      function setState(nextState) {
-        _extends(history, nextState),
-          (history.length = globalHistory.length),
-          transitionManager.notifyListeners(history.location, history.action);
-      }
-      var forceNextPop = !1,
-        ignorePath = null;
-      function handleHashChange() {
-        var path = getHashPath(),
-          encodedPath = encodePath(path);
-        if (path !== encodedPath) replaceHashPath(encodedPath);
-        else {
-          var location = getDOMLocation(),
-            prevLocation = history.location;
-          if (!forceNextPop && locationsAreEqual(prevLocation, location))
-            return;
-          if (ignorePath === createPath(location)) return;
-          (ignorePath = null),
-            (function(location) {
-              if (forceNextPop) (forceNextPop = !1), setState();
-              else {
-                transitionManager.confirmTransitionTo(
-                  location,
-                  "POP",
-                  getUserConfirmation,
-                  function(ok) {
-                    ok
-                      ? setState({ action: "POP", location: location })
-                      : (function(fromLocation) {
-                          var toLocation = history.location,
-                            toIndex = allPaths.lastIndexOf(
-                              createPath(toLocation)
-                            );
-                          -1 === toIndex && (toIndex = 0);
-                          var fromIndex = allPaths.lastIndexOf(
-                            createPath(fromLocation)
-                          );
-                          -1 === fromIndex && (fromIndex = 0);
-                          var delta = toIndex - fromIndex;
-                          delta && ((forceNextPop = !0), go(delta));
-                        })(location);
-                  }
-                );
-              }
-            })(location);
-        }
-      }
-      var path = getHashPath(),
-        encodedPath = encodePath(path);
-      path !== encodedPath && replaceHashPath(encodedPath);
-      var initialLocation = getDOMLocation(),
-        allPaths = [createPath(initialLocation)];
-      function go(n) {
-        globalHistory.go(n);
-      }
-      var listenerCount = 0;
-      function checkDOMListeners(delta) {
-        1 === (listenerCount += delta)
-          ? window.addEventListener(HashChangeEvent$1, handleHashChange)
-          : 0 === listenerCount &&
-            window.removeEventListener(HashChangeEvent$1, handleHashChange);
-      }
-      var isBlocked = !1;
-      var history = {
-        length: globalHistory.length,
-        action: "POP",
-        location: initialLocation,
-        createHref: function(location) {
-          return "#" + encodePath(basename + createPath(location));
-        },
-        push: function(path, state) {
-          var location = createLocation(path, void 0, void 0, history.location);
-          transitionManager.confirmTransitionTo(
-            location,
-            "PUSH",
-            getUserConfirmation,
-            function(ok) {
-              if (ok) {
-                var path = createPath(location),
-                  encodedPath = encodePath(basename + path);
-                if (getHashPath() !== encodedPath) {
-                  (ignorePath = path),
-                    (function(path) {
-                      window.location.hash = path;
-                    })(encodedPath);
-                  var prevIndex = allPaths.lastIndexOf(
-                      createPath(history.location)
-                    ),
-                    nextPaths = allPaths.slice(
-                      0,
-                      -1 === prevIndex ? 0 : prevIndex + 1
-                    );
-                  nextPaths.push(path),
-                    (allPaths = nextPaths),
-                    setState({ action: "PUSH", location: location });
-                } else setState();
-              }
-            }
-          );
-        },
-        replace: function(path, state) {
-          var location = createLocation(path, void 0, void 0, history.location);
-          transitionManager.confirmTransitionTo(
-            location,
-            "REPLACE",
-            getUserConfirmation,
-            function(ok) {
-              if (ok) {
-                var path = createPath(location),
-                  encodedPath = encodePath(basename + path);
-                getHashPath() !== encodedPath &&
-                  ((ignorePath = path), replaceHashPath(encodedPath));
-                var prevIndex = allPaths.indexOf(createPath(history.location));
-                -1 !== prevIndex && (allPaths[prevIndex] = path),
-                  setState({ action: "REPLACE", location: location });
-              }
-            }
-          );
-        },
-        go: go,
-        goBack: function() {
-          go(-1);
-        },
-        goForward: function() {
-          go(1);
-        },
-        block: function(prompt) {
-          void 0 === prompt && (prompt = !1);
-          var unblock = transitionManager.setPrompt(prompt);
-          return (
-            isBlocked || (checkDOMListeners(1), (isBlocked = !0)),
-            function() {
-              return (
-                isBlocked && ((isBlocked = !1), checkDOMListeners(-1)),
-                unblock()
-              );
-            }
-          );
-        },
-        listen: function(listener) {
-          var unlisten = transitionManager.appendListener(listener);
-          return (
-            checkDOMListeners(1),
-            function() {
-              checkDOMListeners(-1), unlisten();
-            }
-          );
-        }
-      };
-      return history;
-    }
-    function clamp(n, lowerBound, upperBound) {
-      return Math.min(Math.max(n, lowerBound), upperBound);
-    }
-    var path_to_regexp = __webpack_require__(2),
-      path_to_regexp_default = __webpack_require__.n(path_to_regexp);
-    __webpack_require__(4);
-    function _objectWithoutPropertiesLoose(source, excluded) {
-      if (null == source) return {};
-      var key,
-        i,
-        target = {},
-        sourceKeys = Object.keys(source);
-      for (i = 0; i < sourceKeys.length; i++)
-        (key = sourceKeys[i]),
-          excluded.indexOf(key) >= 0 || (target[key] = source[key]);
       return target;
-    }
-    __webpack_require__(6);
-    var react_router_context = (function(name) {
-        var context = lib_default()();
+    }).apply(this, arguments);
+}
+function isAbsolute(pathname) {
+  return "/" === pathname.charAt(0);
+}
+function spliceOne(list, index) {
+  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
+    list[i] = list[k];
+  list.pop();
+}
+var _typeof =
+  "function" == typeof Symbol && "symbol" == typeof Symbol.iterator
+    ? function(obj) {
+        return typeof obj;
+      }
+    : function(obj) {
+        return obj &&
+          "function" == typeof Symbol &&
+          obj.constructor === Symbol &&
+          obj !== Symbol.prototype
+          ? "symbol"
+          : typeof obj;
+      };
+var prefix = "Invariant failed";
+function invariant(condition, message) {
+  if (!condition) throw new Error(prefix);
+}
+function addLeadingSlash(path) {
+  return "/" === path.charAt(0) ? path : "/" + path;
+}
+function stripLeadingSlash(path) {
+  return "/" === path.charAt(0) ? path.substr(1) : path;
+}
+function stripBasename(path, prefix) {
+  return (function(path, prefix) {
+    return new RegExp("^" + prefix + "(\\/|\\?|#|$)", "i").test(path);
+  })(path, prefix)
+    ? path.substr(prefix.length)
+    : path;
+}
+function stripTrailingSlash(path) {
+  return "/" === path.charAt(path.length - 1) ? path.slice(0, -1) : path;
+}
+function createPath(location) {
+  var pathname = location.pathname,
+    search = location.search,
+    hash = location.hash,
+    path = pathname || "/";
+  return (
+    search &&
+      "?" !== search &&
+      (path += "?" === search.charAt(0) ? search : "?" + search),
+    hash &&
+      "#" !== hash &&
+      (path += "#" === hash.charAt(0) ? hash : "#" + hash),
+    path
+  );
+}
+function createLocation(path, state, key, currentLocation) {
+  var location;
+  "string" == typeof path
+    ? ((location = (function(path) {
+        var pathname = path || "/",
+          search = "",
+          hash = "",
+          hashIndex = pathname.indexOf("#");
+        -1 !== hashIndex &&
+          ((hash = pathname.substr(hashIndex)),
+          (pathname = pathname.substr(0, hashIndex)));
+        var searchIndex = pathname.indexOf("?");
         return (
-          (context.Provider.displayName = name + ".Provider"),
-          (context.Consumer.displayName = name + ".Consumer"),
-          context
+          -1 !== searchIndex &&
+            ((search = pathname.substr(searchIndex)),
+            (pathname = pathname.substr(0, searchIndex))),
+          {
+            pathname: pathname,
+            search: "?" === search ? "" : search,
+            hash: "#" === hash ? "" : hash
+          }
         );
-      })("Router"),
-      react_router_Router = (function(_React$Component) {
-        function Router(props) {
-          var _this;
-          return (
-            ((_this = _React$Component.call(this, props) || this).state = {
-              location: props.history.location
-            }),
-            (_this._isMounted = !1),
-            (_this._pendingLocation = null),
-            props.staticContext ||
-              (_this.unlisten = props.history.listen(function(location) {
-                _this._isMounted
-                  ? _this.setState({ location: location })
-                  : (_this._pendingLocation = location);
-              })),
-            _this
-          );
-        }
-        _inheritsLoose(Router, _React$Component),
-          (Router.computeRootMatch = function(pathname) {
-            return {
-              path: "/",
-              url: "/",
-              params: {},
-              isExact: "/" === pathname
-            };
-          });
-        var _proto = Router.prototype;
-        return (
-          (_proto.componentDidMount = function() {
-            (this._isMounted = !0),
-              this._pendingLocation &&
-                this.setState({ location: this._pendingLocation });
-          }),
-          (_proto.componentWillUnmount = function() {
-            this.unlisten && this.unlisten();
-          }),
-          (_proto.render = function() {
-            return react_default.a.createElement(
-              react_router_context.Provider,
-              {
-                children: this.props.children || null,
-                value: {
-                  history: this.props.history,
-                  location: this.state.location,
-                  match: Router.computeRootMatch(this.state.location.pathname),
-                  staticContext: this.props.staticContext
-                }
-              }
-            );
-          }),
-          Router
-        );
-      })(react_default.a.Component);
-    react_default.a.Component;
-    react_default.a.Component;
-    var cache$1 = {},
-      cacheLimit$1 = 1e4,
-      cacheCount$1 = 0;
-    function matchPath(pathname, options) {
-      void 0 === options && (options = {}),
-        "string" == typeof options && (options = { path: options });
-      var _options = options,
-        path = _options.path,
-        _options$exact = _options.exact,
-        exact = void 0 !== _options$exact && _options$exact,
-        _options$strict = _options.strict,
-        strict = void 0 !== _options$strict && _options$strict,
-        _options$sensitive = _options.sensitive,
-        sensitive = void 0 !== _options$sensitive && _options$sensitive;
-      return [].concat(path).reduce(function(matched, path) {
-        if (matched) return matched;
-        var _compilePath = (function(path, options) {
-            var cacheKey =
-                "" + options.end + options.strict + options.sensitive,
-              pathCache = cache$1[cacheKey] || (cache$1[cacheKey] = {});
-            if (pathCache[path]) return pathCache[path];
-            var keys = [],
-              result = {
-                regexp: path_to_regexp_default()(path, keys, options),
-                keys: keys
-              };
+      })(path)).state = state)
+    : (void 0 === (location = _extends({}, path)).pathname &&
+        (location.pathname = ""),
+      location.search
+        ? "?" !== location.search.charAt(0) &&
+          (location.search = "?" + location.search)
+        : (location.search = ""),
+      location.hash
+        ? "#" !== location.hash.charAt(0) &&
+          (location.hash = "#" + location.hash)
+        : (location.hash = ""),
+      void 0 !== state &&
+        void 0 === location.state &&
+        (location.state = state));
+  try {
+    location.pathname = decodeURI(location.pathname);
+  } catch (e) {
+    throw e instanceof URIError
+      ? new URIError(
+          'Pathname "' +
+            location.pathname +
+            '" could not be decoded. This is likely caused by an invalid percent-encoding.'
+        )
+      : e;
+  }
+  return (
+    key && (location.key = key),
+    currentLocation
+      ? location.pathname
+        ? "/" !== location.pathname.charAt(0) &&
+          (location.pathname = (function(to) {
+            var from =
+                arguments.length > 1 && void 0 !== arguments[1]
+                  ? arguments[1]
+                  : "",
+              toParts = (to && to.split("/")) || [],
+              fromParts = (from && from.split("/")) || [],
+              isToAbs = to && isAbsolute(to),
+              isFromAbs = from && isAbsolute(from),
+              mustEndAbs = isToAbs || isFromAbs;
+            if (
+              (to && isAbsolute(to)
+                ? (fromParts = toParts)
+                : toParts.length &&
+                  (fromParts.pop(), (fromParts = fromParts.concat(toParts))),
+              !fromParts.length)
+            )
+              return "/";
+            var hasTrailingSlash = void 0;
+            if (fromParts.length) {
+              var last = fromParts[fromParts.length - 1];
+              hasTrailingSlash = "." === last || ".." === last || "" === last;
+            } else hasTrailingSlash = !1;
+            for (var up = 0, i = fromParts.length; i >= 0; i--) {
+              var part = fromParts[i];
+              "." === part
+                ? spliceOne(fromParts, i)
+                : ".." === part
+                ? (spliceOne(fromParts, i), up++)
+                : up && (spliceOne(fromParts, i), up--);
+            }
+            if (!mustEndAbs) for (; up--; up) fromParts.unshift("..");
+            !mustEndAbs ||
+              "" === fromParts[0] ||
+              (fromParts[0] && isAbsolute(fromParts[0])) ||
+              fromParts.unshift("");
+            var result = fromParts.join("/");
             return (
-              cacheCount$1 < cacheLimit$1 &&
-                ((pathCache[path] = result), cacheCount$1++),
+              hasTrailingSlash && "/" !== result.substr(-1) && (result += "/"),
               result
             );
-          })(path, { end: exact, strict: strict, sensitive: sensitive }),
-          regexp = _compilePath.regexp,
-          keys = _compilePath.keys,
-          match = regexp.exec(pathname);
-        if (!match) return null;
-        var url = match[0],
-          values = match.slice(1),
-          isExact = pathname === url;
-        return exact && !isExact
-          ? null
-          : {
-              path: path,
-              url: "/" === path && "" === url ? "/" : url,
-              isExact: isExact,
-              params: keys.reduce(function(memo, key, index) {
-                return (memo[key.name] = values[index]), memo;
-              }, {})
-            };
-      }, null);
-    }
-    react_default.a.Component;
-    function react_router_addLeadingSlash(path) {
-      return "/" === path.charAt(0) ? path : "/" + path;
-    }
-    function react_router_stripBasename(basename, location) {
-      if (!basename) return location;
-      var base = react_router_addLeadingSlash(basename);
-      return 0 !== location.pathname.indexOf(base)
-        ? location
-        : _extends({}, location, {
-            pathname: location.pathname.substr(base.length)
-          });
-    }
-    function createURL(location) {
-      return "string" == typeof location ? location : createPath(location);
-    }
-    function staticHandler(methodName) {
-      return function() {
-        tiny_invariant_esm(!1);
-      };
-    }
-    function noop() {}
-    react_default.a.Component;
-    react_default.a.Component;
-    var react_router_dom_BrowserRouter = (function(_React$Component) {
-      function BrowserRouter() {
-        for (
-          var _this, _len = arguments.length, args = new Array(_len), _key = 0;
-          _key < _len;
-          _key++
-        )
-          args[_key] = arguments[_key];
+          })(location.pathname, currentLocation.pathname))
+        : (location.pathname = currentLocation.pathname)
+      : location.pathname || (location.pathname = "/"),
+    location
+  );
+}
+function locationsAreEqual(a, b) {
+  return (
+    a.pathname === b.pathname &&
+    a.search === b.search &&
+    a.hash === b.hash &&
+    a.key === b.key &&
+    (function valueEqual(a, b) {
+      if (a === b) return !0;
+      if (null == a || null == b) return !1;
+      if (Array.isArray(a))
         return (
-          ((_this =
-            _React$Component.call.apply(
-              _React$Component,
-              [this].concat(args)
-            ) || this).history = createBrowserHistory(_this.props)),
-          _this
+          Array.isArray(b) &&
+          a.length === b.length &&
+          a.every(function(item, index) {
+            return valueEqual(item, b[index]);
+          })
+        );
+      var aType = void 0 === a ? "undefined" : _typeof(a);
+      if (aType !== (void 0 === b ? "undefined" : _typeof(b))) return !1;
+      if ("object" === aType) {
+        var aValue = a.valueOf(),
+          bValue = b.valueOf();
+        if (aValue !== a || bValue !== b) return valueEqual(aValue, bValue);
+        var aKeys = Object.keys(a),
+          bKeys = Object.keys(b);
+        return (
+          aKeys.length === bKeys.length &&
+          aKeys.every(function(key) {
+            return valueEqual(a[key], b[key]);
+          })
         );
       }
+      return !1;
+    })(a.state, b.state)
+  );
+}
+function createTransitionManager() {
+  var prompt = null;
+  var listeners = [];
+  return {
+    setPrompt: function(nextPrompt) {
       return (
-        _inheritsLoose(BrowserRouter, _React$Component),
-        (BrowserRouter.prototype.render = function() {
-          return react_default.a.createElement(react_router_Router, {
-            history: this.history,
-            children: this.props.children
-          });
-        }),
-        BrowserRouter
+        (prompt = nextPrompt),
+        function() {
+          prompt === nextPrompt && (prompt = null);
+        }
       );
-    })(react_default.a.Component);
-    react_default.a.Component;
-    react_default.a.Component;
-    console.log(react_router_dom_BrowserRouter);
+    },
+    confirmTransitionTo: function(
+      location,
+      action,
+      getUserConfirmation,
+      callback
+    ) {
+      if (null != prompt) {
+        var result =
+          "function" == typeof prompt ? prompt(location, action) : prompt;
+        "string" == typeof result
+          ? "function" == typeof getUserConfirmation
+            ? getUserConfirmation(result, callback)
+            : callback(!0)
+          : callback(!1 !== result);
+      } else callback(!0);
+    },
+    appendListener: function(fn) {
+      var isActive = !0;
+      function listener() {
+        isActive && fn.apply(void 0, arguments);
+      }
+      return (
+        listeners.push(listener),
+        function() {
+          (isActive = !1),
+            (listeners = listeners.filter(function(item) {
+              return item !== listener;
+            }));
+        }
+      );
+    },
+    notifyListeners: function() {
+      for (
+        var _len = arguments.length, args = new Array(_len), _key = 0;
+        _key < _len;
+        _key++
+      )
+        args[_key] = arguments[_key];
+      listeners.forEach(function(listener) {
+        return listener.apply(void 0, args);
+      });
+    }
+  };
+}
+var canUseDOM = !(
+  "undefined" == typeof window ||
+  !window.document ||
+  !window.document.createElement
+);
+function getConfirmation(message, callback) {
+  callback(window.confirm(message));
+}
+var PopStateEvent = "popstate",
+  HashChangeEvent = "hashchange";
+function getHistoryState() {
+  try {
+    return window.history.state || {};
+  } catch (e) {
+    return {};
   }
-]);
+}
+function createBrowserHistory(props) {
+  void 0 === props && (props = {}), canUseDOM || invariant(!1);
+  var ua,
+    globalHistory = window.history,
+    canUseHistory =
+      ((-1 === (ua = window.navigator.userAgent).indexOf("Android 2.") &&
+        -1 === ua.indexOf("Android 4.0")) ||
+        -1 === ua.indexOf("Mobile Safari") ||
+        -1 !== ua.indexOf("Chrome") ||
+        -1 !== ua.indexOf("Windows Phone")) &&
+      window.history &&
+      "pushState" in window.history,
+    needsHashChangeListener = !(
+      -1 === window.navigator.userAgent.indexOf("Trident")
+    ),
+    _props = props,
+    _props$forceRefresh = _props.forceRefresh,
+    forceRefresh = void 0 !== _props$forceRefresh && _props$forceRefresh,
+    _props$getUserConfirm = _props.getUserConfirmation,
+    getUserConfirmation =
+      void 0 === _props$getUserConfirm
+        ? getConfirmation
+        : _props$getUserConfirm,
+    _props$keyLength = _props.keyLength,
+    keyLength = void 0 === _props$keyLength ? 6 : _props$keyLength,
+    basename = props.basename
+      ? stripTrailingSlash(addLeadingSlash(props.basename))
+      : "";
+  function getDOMLocation(historyState) {
+    var _ref = historyState || {},
+      key = _ref.key,
+      state = _ref.state,
+      _window$location = window.location,
+      path =
+        _window$location.pathname +
+        _window$location.search +
+        _window$location.hash;
+    return (
+      basename && (path = stripBasename(path, basename)),
+      createLocation(path, state, key)
+    );
+  }
+  function createKey() {
+    return Math.random()
+      .toString(36)
+      .substr(2, keyLength);
+  }
+  var transitionManager = createTransitionManager();
+  function setState(nextState) {
+    _extends(history, nextState),
+      (history.length = globalHistory.length),
+      transitionManager.notifyListeners(history.location, history.action);
+  }
+  function handlePopState(event) {
+    (function(event) {
+      void 0 === event.state && navigator.userAgent.indexOf("CriOS");
+    })(event) || handlePop(getDOMLocation(event.state));
+  }
+  function handleHashChange() {
+    handlePop(getDOMLocation(getHistoryState()));
+  }
+  var forceNextPop = !1;
+  function handlePop(location) {
+    if (forceNextPop) (forceNextPop = !1), setState();
+    else {
+      transitionManager.confirmTransitionTo(
+        location,
+        "POP",
+        getUserConfirmation,
+        function(ok) {
+          ok
+            ? setState({ action: "POP", location: location })
+            : (function(fromLocation) {
+                var toLocation = history.location,
+                  toIndex = allKeys.indexOf(toLocation.key);
+                -1 === toIndex && (toIndex = 0);
+                var fromIndex = allKeys.indexOf(fromLocation.key);
+                -1 === fromIndex && (fromIndex = 0);
+                var delta = toIndex - fromIndex;
+                delta && ((forceNextPop = !0), go(delta));
+              })(location);
+        }
+      );
+    }
+  }
+  var initialLocation = getDOMLocation(getHistoryState()),
+    allKeys = [initialLocation.key];
+  function createHref(location) {
+    return basename + createPath(location);
+  }
+  function go(n) {
+    globalHistory.go(n);
+  }
+  var listenerCount = 0;
+  function checkDOMListeners(delta) {
+    1 === (listenerCount += delta)
+      ? (window.addEventListener(PopStateEvent, handlePopState),
+        needsHashChangeListener &&
+          window.addEventListener(HashChangeEvent, handleHashChange))
+      : 0 === listenerCount &&
+        (window.removeEventListener(PopStateEvent, handlePopState),
+        needsHashChangeListener &&
+          window.removeEventListener(HashChangeEvent, handleHashChange));
+  }
+  var isBlocked = !1;
+  var history = {
+    length: globalHistory.length,
+    action: "POP",
+    location: initialLocation,
+    createHref: createHref,
+    push: function(path, state) {
+      var location = createLocation(path, state, createKey(), history.location);
+      transitionManager.confirmTransitionTo(
+        location,
+        "PUSH",
+        getUserConfirmation,
+        function(ok) {
+          if (ok) {
+            var href = createHref(location),
+              key = location.key,
+              state = location.state;
+            if (canUseHistory)
+              if (
+                (globalHistory.pushState(
+                  { key: key, state: state },
+                  null,
+                  href
+                ),
+                forceRefresh)
+              )
+                window.location.href = href;
+              else {
+                var prevIndex = allKeys.indexOf(history.location.key),
+                  nextKeys = allKeys.slice(
+                    0,
+                    -1 === prevIndex ? 0 : prevIndex + 1
+                  );
+                nextKeys.push(location.key),
+                  (allKeys = nextKeys),
+                  setState({ action: "PUSH", location: location });
+              }
+            else window.location.href = href;
+          }
+        }
+      );
+    },
+    replace: function(path, state) {
+      var location = createLocation(path, state, createKey(), history.location);
+      transitionManager.confirmTransitionTo(
+        location,
+        "REPLACE",
+        getUserConfirmation,
+        function(ok) {
+          if (ok) {
+            var href = createHref(location),
+              key = location.key,
+              state = location.state;
+            if (canUseHistory)
+              if (
+                (globalHistory.replaceState(
+                  { key: key, state: state },
+                  null,
+                  href
+                ),
+                forceRefresh)
+              )
+                window.location.replace(href);
+              else {
+                var prevIndex = allKeys.indexOf(history.location.key);
+                -1 !== prevIndex && (allKeys[prevIndex] = location.key),
+                  setState({ action: "REPLACE", location: location });
+              }
+            else window.location.replace(href);
+          }
+        }
+      );
+    },
+    go: go,
+    goBack: function() {
+      go(-1);
+    },
+    goForward: function() {
+      go(1);
+    },
+    block: function(prompt) {
+      void 0 === prompt && (prompt = !1);
+      var unblock = transitionManager.setPrompt(prompt);
+      return (
+        isBlocked || (checkDOMListeners(1), (isBlocked = !0)),
+        function() {
+          return (
+            isBlocked && ((isBlocked = !1), checkDOMListeners(-1)), unblock()
+          );
+        }
+      );
+    },
+    listen: function(listener) {
+      var unlisten = transitionManager.appendListener(listener);
+      return (
+        checkDOMListeners(1),
+        function() {
+          checkDOMListeners(-1), unlisten();
+        }
+      );
+    }
+  };
+  return history;
+}
+var HashChangeEvent$1 = "hashchange",
+  HashPathCoders = {
+    hashbang: {
+      encodePath: function(path) {
+        return "!" === path.charAt(0) ? path : "!/" + stripLeadingSlash(path);
+      },
+      decodePath: function(path) {
+        return "!" === path.charAt(0) ? path.substr(1) : path;
+      }
+    },
+    noslash: { encodePath: stripLeadingSlash, decodePath: addLeadingSlash },
+    slash: { encodePath: addLeadingSlash, decodePath: addLeadingSlash }
+  };
+function getHashPath() {
+  var href = window.location.href,
+    hashIndex = href.indexOf("#");
+  return -1 === hashIndex ? "" : href.substring(hashIndex + 1);
+}
+function replaceHashPath(path) {
+  var hashIndex = window.location.href.indexOf("#");
+  window.location.replace(
+    window.location.href.slice(0, hashIndex >= 0 ? hashIndex : 0) + "#" + path
+  );
+}
+function createHashHistory(props) {
+  void 0 === props && (props = {}), canUseDOM || invariant(!1);
+  var globalHistory = window.history,
+    _props = (window.navigator.userAgent.indexOf("Firefox"), props),
+    _props$getUserConfirm = _props.getUserConfirmation,
+    getUserConfirmation =
+      void 0 === _props$getUserConfirm
+        ? getConfirmation
+        : _props$getUserConfirm,
+    _props$hashType = _props.hashType,
+    hashType = void 0 === _props$hashType ? "slash" : _props$hashType,
+    basename = props.basename
+      ? stripTrailingSlash(addLeadingSlash(props.basename))
+      : "",
+    _HashPathCoders$hashT = HashPathCoders[hashType],
+    encodePath = _HashPathCoders$hashT.encodePath,
+    decodePath = _HashPathCoders$hashT.decodePath;
+  function getDOMLocation() {
+    var path = decodePath(getHashPath());
+    return (
+      basename && (path = stripBasename(path, basename)), createLocation(path)
+    );
+  }
+  var transitionManager = createTransitionManager();
+  function setState(nextState) {
+    _extends(history, nextState),
+      (history.length = globalHistory.length),
+      transitionManager.notifyListeners(history.location, history.action);
+  }
+  var forceNextPop = !1,
+    ignorePath = null;
+  function handleHashChange() {
+    var path = getHashPath(),
+      encodedPath = encodePath(path);
+    if (path !== encodedPath) replaceHashPath(encodedPath);
+    else {
+      var location = getDOMLocation(),
+        prevLocation = history.location;
+      if (!forceNextPop && locationsAreEqual(prevLocation, location)) return;
+      if (ignorePath === createPath(location)) return;
+      (ignorePath = null),
+        (function(location) {
+          if (forceNextPop) (forceNextPop = !1), setState();
+          else {
+            transitionManager.confirmTransitionTo(
+              location,
+              "POP",
+              getUserConfirmation,
+              function(ok) {
+                ok
+                  ? setState({ action: "POP", location: location })
+                  : (function(fromLocation) {
+                      var toLocation = history.location,
+                        toIndex = allPaths.lastIndexOf(createPath(toLocation));
+                      -1 === toIndex && (toIndex = 0);
+                      var fromIndex = allPaths.lastIndexOf(
+                        createPath(fromLocation)
+                      );
+                      -1 === fromIndex && (fromIndex = 0);
+                      var delta = toIndex - fromIndex;
+                      delta && ((forceNextPop = !0), go(delta));
+                    })(location);
+              }
+            );
+          }
+        })(location);
+    }
+  }
+  var path = getHashPath(),
+    encodedPath = encodePath(path);
+  path !== encodedPath && replaceHashPath(encodedPath);
+  var initialLocation = getDOMLocation(),
+    allPaths = [createPath(initialLocation)];
+  function go(n) {
+    globalHistory.go(n);
+  }
+  var listenerCount = 0;
+  function checkDOMListeners(delta) {
+    1 === (listenerCount += delta)
+      ? window.addEventListener(HashChangeEvent$1, handleHashChange)
+      : 0 === listenerCount &&
+        window.removeEventListener(HashChangeEvent$1, handleHashChange);
+  }
+  var isBlocked = !1;
+  var history = {
+    length: globalHistory.length,
+    action: "POP",
+    location: initialLocation,
+    createHref: function(location) {
+      return "#" + encodePath(basename + createPath(location));
+    },
+    push: function(path, state) {
+      var location = createLocation(path, void 0, void 0, history.location);
+      transitionManager.confirmTransitionTo(
+        location,
+        "PUSH",
+        getUserConfirmation,
+        function(ok) {
+          if (ok) {
+            var path = createPath(location),
+              encodedPath = encodePath(basename + path);
+            if (getHashPath() !== encodedPath) {
+              (ignorePath = path),
+                (function(path) {
+                  window.location.hash = path;
+                })(encodedPath);
+              var prevIndex = allPaths.lastIndexOf(
+                  createPath(history.location)
+                ),
+                nextPaths = allPaths.slice(
+                  0,
+                  -1 === prevIndex ? 0 : prevIndex + 1
+                );
+              nextPaths.push(path),
+                (allPaths = nextPaths),
+                setState({ action: "PUSH", location: location });
+            } else setState();
+          }
+        }
+      );
+    },
+    replace: function(path, state) {
+      var location = createLocation(path, void 0, void 0, history.location);
+      transitionManager.confirmTransitionTo(
+        location,
+        "REPLACE",
+        getUserConfirmation,
+        function(ok) {
+          if (ok) {
+            var path = createPath(location),
+              encodedPath = encodePath(basename + path);
+            getHashPath() !== encodedPath &&
+              ((ignorePath = path), replaceHashPath(encodedPath));
+            var prevIndex = allPaths.indexOf(createPath(history.location));
+            -1 !== prevIndex && (allPaths[prevIndex] = path),
+              setState({ action: "REPLACE", location: location });
+          }
+        }
+      );
+    },
+    go: go,
+    goBack: function() {
+      go(-1);
+    },
+    goForward: function() {
+      go(1);
+    },
+    block: function(prompt) {
+      void 0 === prompt && (prompt = !1);
+      var unblock = transitionManager.setPrompt(prompt);
+      return (
+        isBlocked || (checkDOMListeners(1), (isBlocked = !0)),
+        function() {
+          return (
+            isBlocked && ((isBlocked = !1), checkDOMListeners(-1)), unblock()
+          );
+        }
+      );
+    },
+    listen: function(listener) {
+      var unlisten = transitionManager.appendListener(listener);
+      return (
+        checkDOMListeners(1),
+        function() {
+          checkDOMListeners(-1), unlisten();
+        }
+      );
+    }
+  };
+  return history;
+}
+function clamp(n, lowerBound, upperBound) {
+  return Math.min(Math.max(n, lowerBound), upperBound);
+}
+var isarray =
+    Array.isArray ||
+    function(arr) {
+      return "[object Array]" == Object.prototype.toString.call(arr);
+    },
+  pathToRegexp_1 = pathToRegexp,
+  parse_1 = parse,
+  compile_1 = function(str, options) {
+    return tokensToFunction(parse(str, options));
+  },
+  tokensToFunction_1 = tokensToFunction,
+  tokensToRegExp_1 = tokensToRegExp,
+  PATH_REGEXP = new RegExp(
+    [
+      "(\\\\.)",
+      "([\\/.])?(?:(?:\\:(\\w+)(?:\\(((?:\\\\.|[^\\\\()])+)\\))?|\\(((?:\\\\.|[^\\\\()])+)\\))([+*?])?|(\\*))"
+    ].join("|"),
+    "g"
+  );
+function parse(str, options) {
+  for (
+    var res,
+      tokens = [],
+      key = 0,
+      index = 0,
+      path = "",
+      defaultDelimiter = (options && options.delimiter) || "/";
+    null != (res = PATH_REGEXP.exec(str));
+
+  ) {
+    var m = res[0],
+      escaped = res[1],
+      offset = res.index;
+    if (
+      ((path += str.slice(index, offset)), (index = offset + m.length), escaped)
+    )
+      path += escaped[1];
+    else {
+      var next = str[index],
+        prefix = res[2],
+        name = res[3],
+        capture = res[4],
+        group = res[5],
+        modifier = res[6],
+        asterisk = res[7];
+      path && (tokens.push(path), (path = ""));
+      var partial = null != prefix && null != next && next !== prefix,
+        repeat = "+" === modifier || "*" === modifier,
+        optional = "?" === modifier || "*" === modifier,
+        delimiter = res[2] || defaultDelimiter,
+        pattern = capture || group;
+      tokens.push({
+        name: name || key++,
+        prefix: prefix || "",
+        delimiter: delimiter,
+        optional: optional,
+        repeat: repeat,
+        partial: partial,
+        asterisk: !!asterisk,
+        pattern: pattern
+          ? escapeGroup(pattern)
+          : asterisk
+          ? ".*"
+          : "[^" + escapeString(delimiter) + "]+?"
+      });
+    }
+  }
+  return (
+    index < str.length && (path += str.substr(index)),
+    path && tokens.push(path),
+    tokens
+  );
+}
+function encodeURIComponentPretty(str) {
+  return encodeURI(str).replace(/[\/?#]/g, function(c) {
+    return (
+      "%" +
+      c
+        .charCodeAt(0)
+        .toString(16)
+        .toUpperCase()
+    );
+  });
+}
+function tokensToFunction(tokens) {
+  for (var matches = new Array(tokens.length), i = 0; i < tokens.length; i++)
+    "object" == typeof tokens[i] &&
+      (matches[i] = new RegExp("^(?:" + tokens[i].pattern + ")$"));
+  return function(obj, opts) {
+    for (
+      var path = "",
+        data = obj || {},
+        encode = (opts || {}).pretty
+          ? encodeURIComponentPretty
+          : encodeURIComponent,
+        i = 0;
+      i < tokens.length;
+      i++
+    ) {
+      var token = tokens[i];
+      if ("string" != typeof token) {
+        var segment,
+          value = data[token.name];
+        if (null == value) {
+          if (token.optional) {
+            token.partial && (path += token.prefix);
+            continue;
+          }
+          throw new TypeError('Expected "' + token.name + '" to be defined');
+        }
+        if (isarray(value)) {
+          if (!token.repeat)
+            throw new TypeError(
+              'Expected "' +
+                token.name +
+                '" to not repeat, but received `' +
+                JSON.stringify(value) +
+                "`"
+            );
+          if (0 === value.length) {
+            if (token.optional) continue;
+            throw new TypeError(
+              'Expected "' + token.name + '" to not be empty'
+            );
+          }
+          for (var j = 0; j < value.length; j++) {
+            if (((segment = encode(value[j])), !matches[i].test(segment)))
+              throw new TypeError(
+                'Expected all "' +
+                  token.name +
+                  '" to match "' +
+                  token.pattern +
+                  '", but received `' +
+                  JSON.stringify(segment) +
+                  "`"
+              );
+            path += (0 === j ? token.prefix : token.delimiter) + segment;
+          }
+        } else {
+          if (
+            ((segment = token.asterisk
+              ? encodeURI(value).replace(/[?#]/g, function(c) {
+                  return (
+                    "%" +
+                    c
+                      .charCodeAt(0)
+                      .toString(16)
+                      .toUpperCase()
+                  );
+                })
+              : encode(value)),
+            !matches[i].test(segment))
+          )
+            throw new TypeError(
+              'Expected "' +
+                token.name +
+                '" to match "' +
+                token.pattern +
+                '", but received "' +
+                segment +
+                '"'
+            );
+          path += token.prefix + segment;
+        }
+      } else path += token;
+    }
+    return path;
+  };
+}
+function escapeString(str) {
+  return str.replace(/([.+*?=^!:${}()[\]|\/\\])/g, "\\$1");
+}
+function escapeGroup(group) {
+  return group.replace(/([=!:$\/()])/g, "\\$1");
+}
+function attachKeys(re, keys) {
+  return (re.keys = keys), re;
+}
+function flags(options) {
+  return options.sensitive ? "" : "i";
+}
+function tokensToRegExp(tokens, keys, options) {
+  isarray(keys) || ((options = keys || options), (keys = []));
+  for (
+    var strict = (options = options || {}).strict,
+      end = !1 !== options.end,
+      route = "",
+      i = 0;
+    i < tokens.length;
+    i++
+  ) {
+    var token = tokens[i];
+    if ("string" == typeof token) route += escapeString(token);
+    else {
+      var prefix = escapeString(token.prefix),
+        capture = "(?:" + token.pattern + ")";
+      keys.push(token),
+        token.repeat && (capture += "(?:" + prefix + capture + ")*"),
+        (route += capture = token.optional
+          ? token.partial
+            ? prefix + "(" + capture + ")?"
+            : "(?:" + prefix + "(" + capture + "))?"
+          : prefix + "(" + capture + ")");
+    }
+  }
+  var delimiter = escapeString(options.delimiter || "/"),
+    endsWithDelimiter = route.slice(-delimiter.length) === delimiter;
+  return (
+    strict ||
+      (route =
+        (endsWithDelimiter ? route.slice(0, -delimiter.length) : route) +
+        "(?:" +
+        delimiter +
+        "(?=$))?"),
+    (route += end
+      ? "$"
+      : strict && endsWithDelimiter
+      ? ""
+      : "(?=" + delimiter + "|$)"),
+    attachKeys(new RegExp("^" + route, flags(options)), keys)
+  );
+}
+function pathToRegexp(path, keys, options) {
+  return (
+    isarray(keys) || ((options = keys || options), (keys = [])),
+    (options = options || {}),
+    path instanceof RegExp
+      ? (function(path, keys) {
+          var groups = path.source.match(/\((?!\?)/g);
+          if (groups)
+            for (var i = 0; i < groups.length; i++)
+              keys.push({
+                name: i,
+                prefix: null,
+                delimiter: null,
+                optional: !1,
+                repeat: !1,
+                partial: !1,
+                asterisk: !1,
+                pattern: null
+              });
+          return attachKeys(path, keys);
+        })(path, keys)
+      : isarray(path)
+      ? (function(path, keys, options) {
+          for (var parts = [], i = 0; i < path.length; i++)
+            parts.push(pathToRegexp(path[i], keys, options).source);
+          return attachKeys(
+            new RegExp("(?:" + parts.join("|") + ")", flags(options)),
+            keys
+          );
+        })(path, keys, options)
+      : (function(path, keys, options) {
+          return tokensToRegExp(parse(path, options), keys, options);
+        })(path, keys, options)
+  );
+}
+function _objectWithoutPropertiesLoose(source, excluded) {
+  if (null == source) return {};
+  var key,
+    i,
+    target = {},
+    sourceKeys = Object.keys(source);
+  for (i = 0; i < sourceKeys.length; i++)
+    (key = sourceKeys[i]),
+      excluded.indexOf(key) >= 0 || (target[key] = source[key]);
+  return target;
+}
+(pathToRegexp_1.parse = parse_1),
+  (pathToRegexp_1.compile = compile_1),
+  (pathToRegexp_1.tokensToFunction = tokensToFunction_1),
+  (pathToRegexp_1.tokensToRegExp = tokensToRegExp_1);
+({}[reactIs.ForwardRef] = {
+  $$typeof: !0,
+  render: !0,
+  defaultProps: !0,
+  displayName: !0,
+  propTypes: !0
+});
+var context = (function(name) {
+    var context = createContext();
+    return (
+      (context.Provider.displayName = name + ".Provider"),
+      (context.Consumer.displayName = name + ".Consumer"),
+      context
+    );
+  })("Router"),
+  Router = (function(_React$Component) {
+    function Router(props) {
+      var _this;
+      return (
+        ((_this = _React$Component.call(this, props) || this).state = {
+          location: props.history.location
+        }),
+        (_this._isMounted = !1),
+        (_this._pendingLocation = null),
+        props.staticContext ||
+          (_this.unlisten = props.history.listen(function(location) {
+            _this._isMounted
+              ? _this.setState({ location: location })
+              : (_this._pendingLocation = location);
+          })),
+        _this
+      );
+    }
+    _inheritsLoose(Router, _React$Component),
+      (Router.computeRootMatch = function(pathname) {
+        return { path: "/", url: "/", params: {}, isExact: "/" === pathname };
+      });
+    var _proto = Router.prototype;
+    return (
+      (_proto.componentDidMount = function() {
+        (this._isMounted = !0),
+          this._pendingLocation &&
+            this.setState({ location: this._pendingLocation });
+      }),
+      (_proto.componentWillUnmount = function() {
+        this.unlisten && this.unlisten();
+      }),
+      (_proto.render = function() {
+        return react.createElement(context.Provider, {
+          children: this.props.children || null,
+          value: {
+            history: this.props.history,
+            location: this.state.location,
+            match: Router.computeRootMatch(this.state.location.pathname),
+            staticContext: this.props.staticContext
+          }
+        });
+      }),
+      Router
+    );
+  })(react.Component),
+  cache$1 = (react.Component, react.Component, {}),
+  cacheLimit$1 = 1e4,
+  cacheCount$1 = 0;
+function matchPath(pathname, options) {
+  void 0 === options && (options = {}),
+    "string" == typeof options && (options = { path: options });
+  var _options = options,
+    path = _options.path,
+    _options$exact = _options.exact,
+    exact = void 0 !== _options$exact && _options$exact,
+    _options$strict = _options.strict,
+    strict = void 0 !== _options$strict && _options$strict,
+    _options$sensitive = _options.sensitive,
+    sensitive = void 0 !== _options$sensitive && _options$sensitive;
+  return [].concat(path).reduce(function(matched, path) {
+    if (matched) return matched;
+    var _compilePath = (function(path, options) {
+        var cacheKey = "" + options.end + options.strict + options.sensitive,
+          pathCache = cache$1[cacheKey] || (cache$1[cacheKey] = {});
+        if (pathCache[path]) return pathCache[path];
+        var keys = [],
+          result = { regexp: pathToRegexp_1(path, keys, options), keys: keys };
+        return (
+          cacheCount$1 < cacheLimit$1 &&
+            ((pathCache[path] = result), cacheCount$1++),
+          result
+        );
+      })(path, { end: exact, strict: strict, sensitive: sensitive }),
+      regexp = _compilePath.regexp,
+      keys = _compilePath.keys,
+      match = regexp.exec(pathname);
+    if (!match) return null;
+    var url = match[0],
+      values = match.slice(1),
+      isExact = pathname === url;
+    return exact && !isExact
+      ? null
+      : {
+          path: path,
+          url: "/" === path && "" === url ? "/" : url,
+          isExact: isExact,
+          params: keys.reduce(function(memo, key, index) {
+            return (memo[key.name] = values[index]), memo;
+          }, {})
+        };
+  }, null);
+}
+react.Component;
+function addLeadingSlash$1(path) {
+  return "/" === path.charAt(0) ? path : "/" + path;
+}
+function stripBasename$1(basename, location) {
+  if (!basename) return location;
+  var base = addLeadingSlash$1(basename);
+  return 0 !== location.pathname.indexOf(base)
+    ? location
+    : _extends({}, location, {
+        pathname: location.pathname.substr(base.length)
+      });
+}
+function createURL(location) {
+  return "string" == typeof location ? location : createPath(location);
+}
+function staticHandler(methodName) {
+  return function() {
+    invariant(!1);
+  };
+}
+function noop() {}
+react.Component, react.Component;
+var BrowserRouter = (function(_React$Component) {
+  function BrowserRouter() {
+    for (
+      var _this, _len = arguments.length, args = new Array(_len), _key = 0;
+      _key < _len;
+      _key++
+    )
+      args[_key] = arguments[_key];
+    return (
+      ((_this =
+        _React$Component.call.apply(_React$Component, [this].concat(args)) ||
+        this).history = createBrowserHistory(_this.props)),
+      _this
+    );
+  }
+  return (
+    _inheritsLoose(BrowserRouter, _React$Component),
+    (BrowserRouter.prototype.render = function() {
+      return react.createElement(Router, {
+        history: this.history,
+        children: this.props.children
+      });
+    }),
+    BrowserRouter
+  );
+})(react.Component);
+react.Component;
+react.Component;
+console.log(BrowserRouter);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,26 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
     "@babel/runtime": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.4.tgz",
@@ -12,274 +32,22 @@
         "regenerator-runtime": "^0.12.0"
       }
     },
-    "@webassemblyjs/ast": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",
-      "integrity": "sha512-aJMfngIZ65+t71C3y2nBBg5FFG0Okt9m0XEgWZ7Ywgn1oMAT8cNwx00Uv1cQyHtidq0Xn94R4TAywO+LCQ+ZAQ==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5"
-      }
-    },
-    "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz",
-      "integrity": "sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==",
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
-    "@webassemblyjs/helper-api-error": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.8.5.tgz",
-      "integrity": "sha512-Za/tnzsvnqdaSPOUXHyKJ2XI7PDX64kWtURyGiJJZKVEdFOsdKUCPTNEVFZq3zJ2R0G5wc2PZ5gvdTRFgm81zA==",
-      "dev": true
-    },
-    "@webassemblyjs/helper-buffer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.8.5.tgz",
-      "integrity": "sha512-Ri2R8nOS0U6G49Q86goFIPNgjyl6+oE1abW1pS84BuhP1Qcr5JqMwRFT3Ah3ADDDYGEgGs1iyb1DGX+kAi/c/Q==",
-      "dev": true
-    },
-    "@webassemblyjs/helper-code-frame": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.8.5.tgz",
-      "integrity": "sha512-VQAadSubZIhNpH46IR3yWO4kZZjMxN1opDrzePLdVKAZ+DFjkGD/rf4v1jap744uPVU6yjL/smZbRIIJTOUnKQ==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/wast-printer": "1.8.5"
-      }
-    },
-    "@webassemblyjs/helper-fsm": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.8.5.tgz",
-      "integrity": "sha512-kRuX/saORcg8se/ft6Q2UbRpZwP4y7YrWsLXPbbmtepKr22i8Z4O3V5QE9DbZK908dh5Xya4Un57SDIKwB9eow==",
-      "dev": true
-    },
-    "@webassemblyjs/helper-module-context": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.8.5.tgz",
-      "integrity": "sha512-/O1B236mN7UNEU4t9X7Pj38i4VoU8CcMHyy3l2cV/kIF4U5KoHXDVqcDuOs1ltkac90IM4vZdHc52t1x8Yfs3g==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "mamacro": "^0.0.3"
-      }
-    },
-    "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.8.5.tgz",
-      "integrity": "sha512-Cu4YMYG3Ddl72CbmpjU/wbP6SACcOPVbHN1dI4VJNJVgFwaKf1ppeFJrwydOG3NDHxVGuCfPlLZNyEdIYlQ6QQ==",
-      "dev": true
-    },
-    "@webassemblyjs/helper-wasm-section": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.8.5.tgz",
-      "integrity": "sha512-VV083zwR+VTrIWWtgIUpqfvVdK4ff38loRmrdDBgBT8ADXYsEZ5mPQ4Nde90N3UYatHdYoDIFb7oHzMncI02tA==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5"
-      }
-    },
-    "@webassemblyjs/ieee754": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.8.5.tgz",
-      "integrity": "sha512-aaCvQYrvKbY/n6wKHb/ylAJr27GglahUO89CcGXMItrOBqRarUMxWLJgxm9PJNuKULwN5n1csT9bYoMeZOGF3g==",
-      "dev": true,
-      "requires": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "@webassemblyjs/leb128": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.8.5.tgz",
-      "integrity": "sha512-plYUuUwleLIziknvlP8VpTgO4kqNaH57Y3JnNa6DLpu/sGcP6hbVdfdX5aHAV716pQBKrfuU26BJK29qY37J7A==",
-      "dev": true,
-      "requires": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/utf8": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.8.5.tgz",
-      "integrity": "sha512-U7zgftmQriw37tfD934UNInokz6yTmn29inT2cAetAsaU9YeVCveWEwhKL1Mg4yS7q//NGdzy79nlXh3bT8Kjw==",
-      "dev": true
-    },
-    "@webassemblyjs/wasm-edit": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.8.5.tgz",
-      "integrity": "sha512-A41EMy8MWw5yvqj7MQzkDjU29K7UJq1VrX2vWLzfpRHt3ISftOXqrtojn7nlPsZ9Ijhp5NwuODuycSvfAO/26Q==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/helper-wasm-section": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-opt": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "@webassemblyjs/wast-printer": "1.8.5"
-      }
-    },
-    "@webassemblyjs/wasm-gen": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.8.5.tgz",
-      "integrity": "sha512-BCZBT0LURC0CXDzj5FXSc2FPTsxwp3nWcqXQdOZE4U7h7i8FqtFK5Egia6f9raQLpEKT1VL7zr4r3+QX6zArWg==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
-      }
-    },
-    "@webassemblyjs/wasm-opt": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.8.5.tgz",
-      "integrity": "sha512-HKo2mO/Uh9A6ojzu7cjslGaHaUU14LdLbGEKqTR7PBKwT6LdPtLLh9fPY33rmr5wcOMrsWDbbdCHq4hQUdd37Q==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-buffer": "1.8.5",
-        "@webassemblyjs/wasm-gen": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5"
-      }
-    },
-    "@webassemblyjs/wasm-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.8.5.tgz",
-      "integrity": "sha512-pi0SYE9T6tfcMkthwcgCpL0cM9nRYr6/6fjgDtL6q/ZqKHdMWvxitRi5JcZ7RI4SNJJYnYNaWy5UUrHQy998lw==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-wasm-bytecode": "1.8.5",
-        "@webassemblyjs/ieee754": "1.8.5",
-        "@webassemblyjs/leb128": "1.8.5",
-        "@webassemblyjs/utf8": "1.8.5"
-      }
-    },
-    "@webassemblyjs/wast-parser": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.8.5.tgz",
-      "integrity": "sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/floating-point-hex-parser": "1.8.5",
-        "@webassemblyjs/helper-api-error": "1.8.5",
-        "@webassemblyjs/helper-code-frame": "1.8.5",
-        "@webassemblyjs/helper-fsm": "1.8.5",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webassemblyjs/wast-printer": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.8.5.tgz",
-      "integrity": "sha512-w0U0pD4EhlnvRyeJzBqaVSJAo9w/ce7/WPogeXLzGkO6hzhr4GnQIZ4W4uUt5b9ooAaXPtnXlj0gzsXEOUNYMg==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/wast-parser": "1.8.5",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "@webpack-contrib/config-loader": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@webpack-contrib/config-loader/-/config-loader-1.2.1.tgz",
-      "integrity": "sha512-C7XsS6bXft0aRlyt7YCLg+fm97Mb3tWd+i5fVVlEl0NW5HKy8LoXVKj3mB7ECcEHNEEdHhgzg8gxP+Or8cMj8Q==",
-      "dev": true,
-      "requires": {
-        "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
-        "chalk": "^2.1.0",
-        "cosmiconfig": "^5.0.2",
-        "is-plain-obj": "^1.1.0",
-        "loud-rejection": "^1.6.0",
-        "merge-options": "^1.0.1",
-        "minimist": "^1.2.0",
-        "resolve": "^1.6.0",
-        "webpack-log": "^1.1.2"
-      }
-    },
-    "@webpack-contrib/schema-utils": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@webpack-contrib/schema-utils/-/schema-utils-1.0.0-beta.0.tgz",
-      "integrity": "sha512-LonryJP+FxQQHsjGBi6W786TQB1Oym+agTpY0c+Kj8alnIw+DLUJb6SI8Y1GHGhLCH1yPRrucjObUmxNICQ1pg==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chalk": "^2.3.2",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0",
-        "webpack-log": "^1.1.2"
-      }
-    },
-    "@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true
-    },
-    "@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+    "@types/node": {
+      "version": "11.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
+      "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg==",
       "dev": true
     },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
       "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
-      "dev": true
-    },
-    "acorn-dynamic-import": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-4.0.0.tgz",
-      "integrity": "sha512-d3OEjQV4ROpoflsnUA8HozoIR504TFxNivYEUi6uwz0IYhBkTDXGuWlNdMtybRt3nqVx/L6XqMt0FxkXuWKZhw==",
-      "dev": true
-    },
-    "ajv": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "ajv-errors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
-    },
-    "ajv-keywords": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
-      "dev": true
-    },
-    "ansi-align": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-      "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true,
-      "requires": {
-        "string-width": "^2.0.0"
-      }
-    },
-    "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
@@ -289,42 +57,6 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
-      }
-    },
-    "anymatch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
-      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
-      "dev": true,
-      "requires": {
-        "micromatch": "^3.1.4",
-        "normalize-path": "^2.1.1"
-      },
-      "dependencies": {
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        }
-      }
-    },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-      "dev": true
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -345,22 +77,10 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
-      "dev": true
-    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
     "asap": {
@@ -368,53 +88,10 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
-    "asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
-      "requires": {
-        "util": "0.10.3"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        },
-        "util": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.1"
-          }
-        }
-      }
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
-    },
-    "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
     },
     "atob": {
@@ -484,59 +161,6 @@
         }
       }
     },
-    "base64-js": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
-      "dev": true
-    },
-    "big.js": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
-    },
-    "binary-extensions": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw==",
-      "dev": true
-    },
-    "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
-      "dev": true
-    },
-    "bn.js": {
-      "version": "4.11.8",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-      "dev": true
-    },
-    "boxen": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-      "dev": true,
-      "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -576,141 +200,17 @@
         }
       }
     },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
-      "dev": true
-    },
-    "browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "dev": true,
-      "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "browserify-cipher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-      "dev": true,
-      "requires": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "browserify-des": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-      "dev": true,
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "browserify-rsa": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
-      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.1.0",
-        "randombytes": "^2.0.1"
-      }
-    },
-    "browserify-sign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.1.1",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.2",
-        "elliptic": "^6.0.0",
-        "inherits": "^2.0.1",
-        "parse-asn1": "^5.0.0"
-      }
-    },
-    "browserify-zlib": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "dev": true,
-      "requires": {
-        "pako": "~1.0.5"
-      }
-    },
-    "buffer": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
-      "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        }
-      }
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
-      "dev": true
-    },
-    "builtin-status-codes": {
+    "builtin-modules": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz",
+      "integrity": "sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==",
       "dev": true
-    },
-    "cacache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.3",
-        "chownr": "^1.1.1",
-        "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.3",
-        "graceful-fs": "^4.1.15",
-        "lru-cache": "^5.1.1",
-        "mississippi": "^3.0.0",
-        "mkdirp": "^0.5.1",
-        "move-concurrently": "^1.0.1",
-        "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
-        "ssri": "^6.0.1",
-        "unique-filename": "^1.1.1",
-        "y18n": "^4.0.0"
-      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -729,61 +229,6 @@
         "unset-value": "^1.0.0"
       }
     },
-    "caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "dev": true,
-      "requires": {
-        "callsites": "^2.0.0"
-      }
-    },
-    "caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "dev": true,
-      "requires": {
-        "caller-callsite": "^2.0.0"
-      }
-    },
-    "callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-      "dev": true
-    },
-    "camelcase-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-      "dev": true,
-      "requires": {
-        "camelcase": "^4.1.0",
-        "map-obj": "^2.0.0",
-        "quick-lru": "^1.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
-      }
-    },
-    "capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-      "dev": true
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -793,57 +238,6 @@
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
-      }
-    },
-    "chokidar": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.2.tgz",
-      "integrity": "sha512-IwXUx0FXc5ibYmPC2XeEj5mpXoV66sR+t3jqu2NS2GYwCktt3KF1/Qqjws/NkegajBA4RbZ5+DDwlOiJsxDHEg==",
-      "dev": true,
-      "requires": {
-        "anymatch": "^2.0.0",
-        "async-each": "^1.0.1",
-        "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
-        "glob-parent": "^3.1.0",
-        "inherits": "^2.0.3",
-        "is-binary-path": "^1.0.0",
-        "is-glob": "^4.0.0",
-        "normalize-path": "^3.0.0",
-        "path-is-absolute": "^1.0.0",
-        "readdirp": "^2.2.1",
-        "upath": "^1.1.0"
-      }
-    },
-    "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
-      "dev": true
-    },
-    "chrome-trace-event": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-      "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
-      "dev": true,
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
-    "ci-info": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-      "dev": true
-    },
-    "cipher-base": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
       }
     },
     "class-utils": {
@@ -868,33 +262,6 @@
           }
         }
       }
-    },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "^2.0.0"
-      }
-    },
-    "cli-spinners": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
-      "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
-      "dev": true
-    },
-    "clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -927,12 +294,6 @@
       "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
       "dev": true
     },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -944,61 +305,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
-    },
-    "configstore": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
-      "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-      "dev": true,
-      "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      }
-    },
-    "console-browserify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "^0.1.4"
-      }
-    },
-    "constants-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
-      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
-      "dev": true
-    },
-    "copy-concurrently": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
-      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.1.1",
-        "fs-write-stream-atomic": "^1.0.8",
-        "iferr": "^0.1.5",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.0"
-      }
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -1017,65 +323,6 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
-      "dev": true,
-      "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
-        "parse-json": "^4.0.0"
-      }
-    },
-    "create-ecdh": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.0.0"
-      }
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "^1.0.0"
-      }
-    },
-    "create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
-      "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
-      "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "create-react-context": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
@@ -1084,90 +331,6 @@
         "fbjs": "^0.8.0",
         "gud": "^1.0.0"
       }
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
-      },
-      "dependencies": {
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
-          "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
-          }
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
-        }
-      }
-    },
-    "crypto-browserify": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
-      "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-      "dev": true,
-      "requires": {
-        "browserify-cipher": "^1.0.0",
-        "browserify-sign": "^4.0.0",
-        "create-ecdh": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "create-hmac": "^1.1.0",
-        "diffie-hellman": "^5.0.0",
-        "inherits": "^2.0.1",
-        "pbkdf2": "^3.0.3",
-        "public-encrypt": "^4.0.0",
-        "randombytes": "^2.0.0",
-        "randomfill": "^1.0.3"
-      }
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-      "dev": true
-    },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "^1.0.1"
-      }
-    },
-    "cyclist": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-      "dev": true
-    },
-    "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "^0.10.9"
-      }
-    },
-    "date-now": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
-      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
-      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -1178,68 +341,11 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
-      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
-      "dev": true,
-      "requires": {
-        "xregexp": "4.0.0"
-      }
-    },
-    "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
-      "dev": true,
-      "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
-      "dependencies": {
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        }
-      }
-    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "dev": true,
-      "requires": {
-        "clone": "^1.0.2"
-      }
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -1282,81 +388,6 @@
         }
       }
     },
-    "des.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
-      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "domain-browser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
-      "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
-      "dev": true
-    },
-    "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "dev": true,
-      "requires": {
-        "is-obj": "^1.0.0"
-      }
-    },
-    "duplexer3": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-      "dev": true
-    },
-    "duplexify": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
-      }
-    },
-    "emojis-list": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
-    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -1365,168 +396,23 @@
         "iconv-lite": "~0.4.13"
       }
     },
-    "end-of-stream": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "dev": true,
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
-    "enhanced-resolve": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-      "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "memory-fs": "^0.4.0",
-        "tapable": "^1.0.0"
-      }
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "~1.0.1"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
-    "es5-ext": {
-      "version": "0.10.48",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.48.tgz",
-      "integrity": "sha512-CdRvPlX/24Mj5L4NVxTs4804sxiS2CjVprgCmrgoDkdmjdY4D+ySHa7K3jJf8R40dFg0tIm3z/dk326LrnuSGw==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.1",
-        "next-tick": "1"
-      }
-    },
-    "es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "es6-symbol": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "eslint-scope": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.2.tgz",
-      "integrity": "sha512-5q1+B/ogmHl8+paxtOKx38Z8LtWkVGuNt3+GQNErqwLl6ViNp/gdJGMCjZNxZ8j/VYjDNZ2Fo+eQc1TAVPIzbg==",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+    "estree-walker": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.2.tgz",
+      "integrity": "sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==",
       "dev": true
     },
-    "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^4.1.0"
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
-    },
-    "events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-Dc381HFWJzEOhQ+d8pkNon++bk9h6cdAoAj4iE6Q4y6xgTzySWXlKn05/TVNpjnfRqi/X0EpJEJohPjNI3zpVA==",
-      "dev": true
-    },
-    "evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
-      "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      }
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -1649,18 +535,6 @@
         }
       }
     },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
     "fbjs": {
       "version": "0.8.17",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
@@ -1674,12 +548,6 @@
         "setimmediate": "^1.0.5",
         "ua-parser-js": "^0.7.18"
       }
-    },
-    "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
-      "dev": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -1704,36 +572,6 @@
         }
       }
     },
-    "find-cache-dir": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-      "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^1.0.0",
-        "pkg-dir": "^3.0.0"
-      }
-    },
-    "find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "dev": true,
-      "requires": {
-        "locate-path": "^3.0.0"
-      }
-    },
-    "flush-write-stream": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
-      "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.3.6"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -1749,667 +587,10 @@
         "map-cache": "^0.2.2"
       }
     },
-    "from2": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
-      }
-    },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
-      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "^2.9.2",
-        "node-pre-gyp": "^0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "balanced-match": "^1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "^3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minipass": {
-          "version": "2.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        },
-        "minizlib": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "^2.2.1"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.1",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.2.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "wrappy": "1"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "^0.6.0",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.4",
-            "minizlib": "^1.1.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "^1.0.2 || 2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "yallist": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-      "dev": true
-    },
-    "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dev": true,
-      "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
-      }
-    },
-    "global-dirs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
-      "requires": {
-        "ini": "^1.3.4"
-      }
-    },
-    "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "^3.0.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
-        "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "gud": {
@@ -2417,25 +598,10 @@
       "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-value": {
@@ -2470,26 +636,6 @@
         }
       }
     },
-    "hash-base": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-      "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "history": {
       "version": "4.8.0-beta.0",
       "resolved": "https://registry.npmjs.org/history/-/history-4.8.0-beta.0.tgz",
@@ -2503,17 +649,6 @@
         "value-equal": "^0.4.0"
       }
     },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
     "hoist-non-react-statics": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
@@ -2521,18 +656,6 @@
       "requires": {
         "react-is": "^16.7.0"
       }
-    },
-    "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
-      "dev": true
-    },
-    "https-browserify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
-      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
-      "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -2542,142 +665,10 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
-    "ieee754": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
-      "dev": true
-    },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
-    },
-    "import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
-      "dev": true,
-      "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
-      }
-    },
-    "import-lazy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
-      "dev": true
-    },
-    "import-local": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
-      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
-      "dev": true,
-      "requires": {
-        "pkg-dir": "^2.0.0",
-        "resolve-cwd": "^2.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
-          "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.1.0"
-          }
-        }
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "dev": true
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
-    },
-    "irregular-plurals": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-2.0.0.tgz",
-      "integrity": "sha512-Y75zBYLkh0lJ9qxeHlMjQ7bSbyiSqNW/UOPWDmzC7cXskL1hekSITh1Oc6JV0XCWWZ9DE8VYSB71xocLk3gmGw==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -2700,41 +691,11 @@
         }
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-binary-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^1.0.0"
-      }
-    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
-    },
-    "is-ci": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "^1.5.0"
-      }
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -2756,12 +717,6 @@
         }
       }
     },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -2781,53 +736,16 @@
         }
       }
     },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
-      "dev": true
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-installed-globally": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
-      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
-      "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-npm": {
+    "is-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
     },
     "is-number": {
@@ -2850,27 +768,6 @@
         }
       }
     },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2880,40 +777,10 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
     },
     "is-windows": {
       "version": "1.0.2",
@@ -2921,22 +788,10 @@
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -2953,120 +808,38 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
+    "jest-worker": {
+      "version": "24.4.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.4.0.tgz",
+      "integrity": "sha512-BH9X/klG9vxwoO99ZBUbZFfV8qO0XNZ5SIiCyYK2zOuJBl6YJVAeNIQjcoOVNu4HGEHeYEKsUWws8kSlSbZ9YQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^1.0.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-    },
-    "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
-      "dev": true,
-      "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      }
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
     },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
       "dev": true
-    },
-    "latest-version": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-      "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "dev": true,
-      "requires": {
-        "package-json": "^4.0.0"
-      }
-    },
-    "load-json-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^4.0.0",
-        "pify": "^3.0.0",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "loader-runner": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
-      "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==",
-      "dev": true
-    },
-    "loader-utils": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-      "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-      "dev": true,
-      "requires": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^2.0.0",
-        "json5": "^1.0.1"
-      }
-    },
-    "locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "dev": true,
-      "requires": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      }
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.1"
-      }
-    },
-    "loglevelnext": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/loglevelnext/-/loglevelnext-1.0.5.tgz",
-      "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
-      "dev": true,
-      "requires": {
-        "es6-symbol": "^3.1.1",
-        "object.assign": "^4.1.0"
-      }
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -3076,56 +849,19 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+    "magic-string": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.2.tgz",
+      "integrity": "sha512-iLs9mPjh9IuTtRsqqhNGYcZXGei0Nh/A4xirrsqW7c+QhKVFL2vm7U09ru6cHRD22azaP/wMDgI+HCqbETMTtg==",
       "dev": true,
       "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
+        "sourcemap-codec": "^1.4.4"
       }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
-      "requires": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
-    "mamacro": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/mamacro/-/mamacro-0.0.3.tgz",
-      "integrity": "sha512-qMEwh+UujcQ+kbz3T6V+wAmO2U8veoq2w+3wY8MquqwVA3jChfwY+Tk52GZKDfACEPjuZ7r2oJLejwpt8jtwTA==",
-      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-      "dev": true
-    },
-    "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
       "dev": true
     },
     "map-visit": {
@@ -3137,57 +873,13 @@
         "object-visit": "^1.0.0"
       }
     },
-    "md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
-      "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "meant": {
+    "merge-stream": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
-      "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg==",
-      "dev": true
-    },
-    "memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
       "dev": true,
       "requires": {
-        "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
-      }
-    },
-    "meow": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-      "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-      "dev": true,
-      "requires": {
-        "camelcase-keys": "^4.0.0",
-        "decamelize-keys": "^1.0.0",
-        "loud-rejection": "^1.0.0",
-        "minimist-options": "^3.0.1",
-        "normalize-package-data": "^2.3.4",
-        "read-pkg-up": "^3.0.0",
-        "redent": "^2.0.0",
-        "trim-newlines": "^2.0.0",
-        "yargs-parser": "^10.0.0"
-      }
-    },
-    "merge-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
-      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^1.1"
       }
     },
     "micromatch": {
@@ -3211,34 +903,6 @@
         "to-regex": "^3.0.2"
       }
     },
-    "miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "dev": true
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -3246,40 +910,6 @@
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
-    },
-    "minimist-options": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0"
-      }
-    },
-    "mississippi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-      "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-      "dev": true,
-      "requires": {
-        "concat-stream": "^1.5.0",
-        "duplexify": "^3.4.2",
-        "end-of-stream": "^1.1.0",
-        "flush-write-stream": "^1.0.0",
-        "from2": "^2.1.0",
-        "parallel-transform": "^1.1.0",
-        "pump": "^3.0.0",
-        "pumpify": "^1.3.3",
-        "stream-each": "^1.1.0",
-        "through2": "^2.0.0"
       }
     },
     "mixin-deep": {
@@ -3303,49 +933,11 @@
         }
       }
     },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
-      }
-    },
-    "move-concurrently": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
-      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
-      "dev": true,
-      "requires": {
-        "aproba": "^1.1.1",
-        "copy-concurrently": "^1.0.0",
-        "fs-write-stream-atomic": "^1.0.8",
-        "mkdirp": "^0.5.1",
-        "rimraf": "^2.5.4",
-        "run-queue": "^1.0.3"
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
-      "dev": true,
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -3366,18 +958,6 @@
         "to-regex": "^3.0.1"
       }
     },
-    "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
-      "dev": true
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
-    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -3385,72 +965,6 @@
       "requires": {
         "encoding": "^0.1.11",
         "is-stream": "^1.0.1"
-      }
-    },
-    "node-libs-browser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-      "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
-      "dev": true,
-      "requires": {
-        "assert": "^1.1.1",
-        "browserify-zlib": "^0.2.0",
-        "buffer": "^4.3.0",
-        "console-browserify": "^1.1.0",
-        "constants-browserify": "^1.0.0",
-        "crypto-browserify": "^3.11.0",
-        "domain-browser": "^1.1.1",
-        "events": "^3.0.0",
-        "https-browserify": "^1.0.0",
-        "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.0",
-        "process": "^0.11.10",
-        "punycode": "^1.2.4",
-        "querystring-es3": "^0.2.0",
-        "readable-stream": "^2.3.3",
-        "stream-browserify": "^2.0.1",
-        "stream-http": "^2.7.2",
-        "string_decoder": "^1.0.0",
-        "timers-browserify": "^2.0.4",
-        "tty-browserify": "0.0.0",
-        "url": "^0.11.0",
-        "util": "^0.11.0",
-        "vm-browserify": "0.0.4"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        }
-      }
-    },
-    "normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
-    },
-    "npm-run-path": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "^2.0.0"
       }
     },
     "object-assign": {
@@ -3489,12 +1003,6 @@
         }
       }
     },
-    "object-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-      "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -3502,18 +1010,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
-      }
-    },
-    "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
       }
     },
     "object.pick": {
@@ -3525,188 +1021,10 @@
         "isobject": "^3.0.1"
       }
     },
-    "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "^1.0.0"
-      }
-    },
-    "opn": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
-      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
-      "dev": true,
-      "requires": {
-        "is-wsl": "^1.1.0"
-      }
-    },
-    "ora": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-2.1.0.tgz",
-      "integrity": "sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.3.1",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^1.1.0",
-        "log-symbols": "^2.2.0",
-        "strip-ansi": "^4.0.0",
-        "wcwidth": "^1.0.1"
-      }
-    },
-    "os-browserify": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
-      "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
-      "dev": true
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-limit": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-      "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
-      "dev": true,
-      "requires": {
-        "p-try": "^2.0.0"
-      }
-    },
-    "p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "dev": true,
-      "requires": {
-        "p-limit": "^2.0.0"
-      }
-    },
-    "p-try": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
-      "dev": true
-    },
-    "package-json": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-      "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true,
-      "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
-      }
-    },
-    "pako": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
-      "dev": true
-    },
-    "parallel-transform": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-      "dev": true,
-      "requires": {
-        "cyclist": "~0.2.2",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.1.5"
-      }
-    },
-    "parse-asn1": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.4.tgz",
-      "integrity": "sha512-Qs5duJcuvNExRfFZ99HDD3z4mAi3r9Wl/FOjEOijlxwCZs7E7mW2vjTpgQ4J8LpTF8x5v+1Vn5UQFejmWT11aw==",
-      "dev": true,
-      "requires": {
-        "asn1.js": "^4.0.0",
-        "browserify-aes": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.0",
-        "pbkdf2": "^3.0.3",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      }
-    },
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-      "dev": true
-    },
-    "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
-      "dev": true
-    },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
-    "path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-      "dev": true
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "path-key": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
@@ -3723,80 +1041,16 @@
         "isarray": "0.0.1"
       }
     },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-      "dev": true,
-      "requires": {
-        "pify": "^3.0.0"
-      }
-    },
-    "pbkdf2": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-      "integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
-      "dev": true,
-      "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
-    },
-    "pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0"
-      }
-    },
-    "plur": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-3.0.1.tgz",
-      "integrity": "sha512-lJl0ojUynAM1BZn58Pas2WT/TXeC1+bS+UqShl0x9+49AtOn7DixRXVzaC8qrDOIxNDmepKnLuMTH7NQmkX0PA==",
-      "dev": true,
-      "requires": {
-        "irregular-plurals": "^2.0.0"
-      }
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
     "prettier": {
       "version": "1.16.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
       "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
-      "dev": true
-    },
-    "pretty-bytes": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.1.0.tgz",
-      "integrity": "sha512-wa5+qGVg9Yt7PB6rYm3kXlKzgzgivYTLRandezh43jjRqgyDyP+9YxfJpJiLs9yKD1WeU8/OvtToWpW7255FtA==",
-      "dev": true
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "process-nextick-args": {
@@ -3813,12 +1067,6 @@
         "asap": "~2.0.3"
       }
     },
-    "promise-inflight": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
-      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
-      "dev": true
-    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -3827,120 +1075,6 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
-      }
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "public-encrypt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-      "dev": true,
-      "requires": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-      "dev": true,
-      "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
-    "querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
-    },
-    "querystring-es3": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
-      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
-      "dev": true
-    },
-    "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-      "dev": true
-    },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "randomfill": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
       }
     },
     "react": {
@@ -3990,72 +1124,6 @@
         "tiny-warning": "^1.0.0"
       }
     },
-    "read-pkg": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-      "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "^4.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^3.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-      "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-      "dev": true,
-      "requires": {
-        "find-up": "^2.0.0",
-        "read-pkg": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-          "dev": true,
-          "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        }
-      }
-    },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
@@ -4079,27 +1147,6 @@
         }
       }
     },
-    "readdirp": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "micromatch": "^3.1.10",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "redent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-      "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-      "dev": true,
-      "requires": {
-        "indent-string": "^3.0.0",
-        "strip-indent": "^2.0.0"
-      }
-    },
     "regenerator-runtime": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
@@ -4114,31 +1161,6 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
-    },
-    "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-      "dev": true,
-      "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "^1.0.1"
-      }
-    },
-    "remove-trailing-separator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -4161,21 +1183,6 @@
         "path-parse": "^1.0.6"
       }
     },
-    "resolve-cwd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
-      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-      "dev": true,
-      "requires": {
-        "resolve-from": "^3.0.0"
-      }
-    },
-    "resolve-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-      "dev": true
-    },
     "resolve-pathname": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
@@ -4187,48 +1194,85 @@
       "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+    "rollup": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.6.0.tgz",
+      "integrity": "sha512-qu9iWyuiOxAuBM8cAwLuqPclYdarIpayrkfQB7aTGTiyYPbvx+qVF33sIznfq4bxZCiytQux/FvZieUBAXivCw==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "@types/estree": "0.0.39",
+        "@types/node": "^11.9.5",
+        "acorn": "^6.1.1"
       }
     },
-    "ripemd160": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
-      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+    "rollup-plugin-commonjs": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-9.2.1.tgz",
+      "integrity": "sha512-X0A/Cp/t+zbONFinBhiTZrfuUaVwRIp4xsbKq/2ohA2CDULa/7ONSJTelqxon+Vds2R2t2qJTqJQucKUC8GKkw==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "estree-walker": "^0.5.2",
+        "magic-string": "^0.25.1",
+        "resolve": "^1.10.0",
+        "rollup-pluginutils": "^2.3.3"
       }
     },
-    "run-queue": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
-      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+    "rollup-plugin-node-resolve": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz",
+      "integrity": "sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==",
       "dev": true,
       "requires": {
-        "aproba": "^1.1.1"
+        "builtin-modules": "^3.0.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.10.0"
+      }
+    },
+    "rollup-plugin-replace": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-replace/-/rollup-plugin-replace-2.1.0.tgz",
+      "integrity": "sha512-SxrAIgpH/B5/W4SeULgreOemxcpEgKs2gcD42zXw50bhqGWmcnlXneVInQpAqzA/cIly4bJrOpeelmB9p4YXSQ==",
+      "dev": true,
+      "requires": {
+        "magic-string": "^0.25.1",
+        "minimatch": "^3.0.2",
+        "rollup-pluginutils": "^2.0.1"
+      }
+    },
+    "rollup-plugin-terser": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz",
+      "integrity": "sha512-wPANT5XKVJJ8RDUN0+wIr7UPd0lIXBo4UdJ59VmlPCtlFsE20AM+14pe+tk7YunCsWEiuzkDBY3QIkSCjtrPXg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.0.0",
+        "serialize-javascript": "^1.6.1",
+        "terser": "^3.14.1"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.4.1.tgz",
+      "integrity": "sha512-wesMQ9/172IJDIW/lYWm0vW0LiKe5Ekjws481R7z9WTRtmO59cqyM/2uUlxvf6yzm/fElFmHUobeQOYz46dZJw==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.0",
+        "micromatch": "^3.1.10"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.0.tgz",
+          "integrity": "sha512-peq1RfVAVzr3PU/jL31RaOjUKLoZJpObQWJJ+LgfcxDUifyLZ1RjPQZTl0pzj2uJ45b7A7XpyppXvxdEqzo4rw==",
+          "dev": true
+        }
       }
     },
     "safe-buffer": {
@@ -4258,32 +1302,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "schema-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-      "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.1.0",
-        "ajv-errors": "^1.0.0",
-        "ajv-keywords": "^3.1.0"
-      }
-    },
-    "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
-      "dev": true
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "^5.0.3"
       }
     },
     "serialize-javascript": {
@@ -4319,37 +1337,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -4458,12 +1445,6 @@
         }
       }
     },
-    "source-list-map": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
-      "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==",
-      "dev": true
-    },
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -4484,9 +1465,9 @@
       }
     },
     "source-map-support": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.10.tgz",
-      "integrity": "sha512-YfQ3tQFTK/yzlGJuX8pTwa4tifQj4QS2Mj7UegOu8jAz59MqIiMGPXxQhVQiIMNzayuUSF/jEuVnfFF5JqybmQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -4507,36 +1488,10 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
-      "dev": true,
-      "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-      "dev": true,
-      "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "spdx-license-ids": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz",
-      "integrity": "sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==",
+    "sourcemap-codec": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.4.tgz",
+      "integrity": "sha512-CYAPYdBu34781kLHkaW3m6b/uUSyMOC2R61gcYMWooeuaGtjof86ZA/8T+qVPPt7np1085CR9hmMGrySwEc8Xg==",
       "dev": true
     },
     "split-string": {
@@ -4546,21 +1501,6 @@
       "dev": true,
       "requires": {
         "extend-shallow": "^3.0.0"
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "ssri": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-      "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-      "dev": true,
-      "requires": {
-        "figgy-pudding": "^3.5.1"
       }
     },
     "static-extend": {
@@ -4584,55 +1524,6 @@
         }
       }
     },
-    "stream-browserify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
-      "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
-      "dev": true,
-      "requires": {
-        "inherits": "~2.0.1",
-        "readable-stream": "^2.0.2"
-      }
-    },
-    "stream-each": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
-      "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
-      "dev": true,
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
-    "stream-http": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
-      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
-      "dev": true,
-      "requires": {
-        "builtin-status-codes": "^3.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.6",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
-      }
-    },
-    "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      }
-    },
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -4642,39 +1533,6 @@
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^3.0.0"
-      }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
-      "dev": true
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -4682,21 +1540,6 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      }
-    },
-    "tapable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-      "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA==",
-      "dev": true
-    },
-    "term-size": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
-      "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "requires": {
-        "execa": "^0.7.0"
       }
     },
     "terser": {
@@ -4718,61 +1561,6 @@
         }
       }
     },
-    "terser-webpack-plugin": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.2.3.tgz",
-      "integrity": "sha512-GOK7q85oAb/5kE12fMuLdn2btOS9OBZn4VsecpHDywoUC/jLhSAKOiYo0ezx7ss2EXPMzyEWFoE0s1WLE+4+oA==",
-      "dev": true,
-      "requires": {
-        "cacache": "^11.0.2",
-        "find-cache-dir": "^2.0.0",
-        "schema-utils": "^1.0.0",
-        "serialize-javascript": "^1.4.0",
-        "source-map": "^0.6.1",
-        "terser": "^3.16.1",
-        "webpack-sources": "^1.1.0",
-        "worker-farm": "^1.5.2"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "requires": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
-    },
-    "timers-browserify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.10.tgz",
-      "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
-      "dev": true,
-      "requires": {
-        "setimmediate": "^1.0.4"
-      }
-    },
     "tiny-invariant": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.3.tgz",
@@ -4782,18 +1570,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.2.tgz",
       "integrity": "sha512-rru86D9CpQRLvsFG5XFdy0KdLAvjdQDyZCsRcuu60WtzFylDM3eAWSxEVz5kzL2Gp544XiUvPbVKtOA/txLi9Q=="
-    },
-    "titleize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/titleize/-/titleize-1.0.1.tgz",
-      "integrity": "sha512-rUwGDruKq1gX+FFHbTl5qjI7teVO7eOe+C8IcQ7QT+1BK3eEUXJqbZcBOeaRP4FwSC/C1A5jDoIVta0nIQ9yew==",
-      "dev": true
-    },
-    "to-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
-      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -4837,30 +1613,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "trim-newlines": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-      "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-      "dev": true
-    },
-    "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-      "dev": true
-    },
-    "tty-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
-      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
-      "dev": true
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
     "ua-parser-js": {
       "version": "0.7.19",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
@@ -4899,33 +1651,6 @@
             "to-object-path": "^0.3.0"
           }
         }
-      }
-    },
-    "unique-filename": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
-      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "dev": true,
-      "requires": {
-        "unique-slug": "^2.0.0"
-      }
-    },
-    "unique-slug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "^0.1.4"
-      }
-    },
-    "unique-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-      "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "^1.0.0"
       }
     },
     "unset-value": {
@@ -4974,77 +1699,11 @@
         }
       }
     },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
-    },
-    "upath": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
-      "dev": true
-    },
-    "update-notifier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-      "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-      "dev": true,
-      "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
-      }
-    },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
-    },
-    "url": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
-      "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
-          "dev": true
-        }
-      }
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "^1.0.1"
-      }
     },
     "use": {
       "version": "3.1.1",
@@ -5052,292 +1711,21 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "util": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
-      "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
-    },
-    "v8-compile-cache": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.0.2.tgz",
-      "integrity": "sha512-1wFuMUIM16MDJRCrpbpuEPTUGmM5QMUg0cr3KFwra2XgOgFcPGDQHDh3CszSCD2Zewc/dh/pamNEW8CbfDebUw==",
-      "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
     "value-equal": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
       "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
     },
-    "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
-    },
-    "watchpack": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
-      "dev": true,
-      "requires": {
-        "chokidar": "^2.0.2",
-        "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
-      }
-    },
-    "wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
-      "dev": true,
-      "requires": {
-        "defaults": "^1.0.3"
-      }
-    },
-    "webpack": {
-      "version": "4.29.6",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.29.6.tgz",
-      "integrity": "sha512-MwBwpiE1BQpMDkbnUUaW6K8RFZjljJHArC6tWQJoFm0oQtfoSebtg4Y7/QHnJ/SddtjYLHaKGX64CFjG5rehJw==",
-      "dev": true,
-      "requires": {
-        "@webassemblyjs/ast": "1.8.5",
-        "@webassemblyjs/helper-module-context": "1.8.5",
-        "@webassemblyjs/wasm-edit": "1.8.5",
-        "@webassemblyjs/wasm-parser": "1.8.5",
-        "acorn": "^6.0.5",
-        "acorn-dynamic-import": "^4.0.0",
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0",
-        "chrome-trace-event": "^1.0.0",
-        "enhanced-resolve": "^4.1.0",
-        "eslint-scope": "^4.0.0",
-        "json-parse-better-errors": "^1.0.2",
-        "loader-runner": "^2.3.0",
-        "loader-utils": "^1.1.0",
-        "memory-fs": "~0.4.1",
-        "micromatch": "^3.1.8",
-        "mkdirp": "~0.5.0",
-        "neo-async": "^2.5.0",
-        "node-libs-browser": "^2.0.0",
-        "schema-utils": "^1.0.0",
-        "tapable": "^1.1.0",
-        "terser-webpack-plugin": "^1.1.0",
-        "watchpack": "^1.5.0",
-        "webpack-sources": "^1.3.0"
-      }
-    },
-    "webpack-command": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/webpack-command/-/webpack-command-0.4.2.tgz",
-      "integrity": "sha512-2JZRlV+eT2nsw0DGDS/F4ndv0e/QVkyYj4/1fagp9DbjRagQ02zuVzELp/QF5mrCESKKvnXiBQoaBJUOjAMp8w==",
-      "dev": true,
-      "requires": {
-        "@webpack-contrib/config-loader": "^1.2.0",
-        "@webpack-contrib/schema-utils": "^1.0.0-beta.0",
-        "camelcase": "^5.0.0",
-        "chalk": "^2.3.2",
-        "debug": "^3.1.0",
-        "decamelize": "^2.0.0",
-        "enhanced-resolve": "^4.0.0",
-        "import-local": "^1.0.0",
-        "isobject": "^3.0.1",
-        "loader-utils": "^1.1.0",
-        "log-symbols": "^2.2.0",
-        "loud-rejection": "^1.6.0",
-        "meant": "^1.0.1",
-        "meow": "^5.0.0",
-        "merge-options": "^1.0.0",
-        "object.values": "^1.0.4",
-        "opn": "^5.3.0",
-        "ora": "^2.1.0",
-        "plur": "^3.0.0",
-        "pretty-bytes": "^5.0.0",
-        "strip-ansi": "^4.0.0",
-        "text-table": "^0.2.0",
-        "titleize": "^1.0.1",
-        "update-notifier": "^2.3.0",
-        "v8-compile-cache": "^2.0.0",
-        "webpack-log": "^1.1.2",
-        "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
-        }
-      }
-    },
-    "webpack-log": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/webpack-log/-/webpack-log-1.2.0.tgz",
-      "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.1.0",
-        "log-symbols": "^2.1.0",
-        "loglevelnext": "^1.0.1",
-        "uuid": "^3.1.0"
-      }
-    },
-    "webpack-sources": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz",
-      "integrity": "sha512-OiVgSrbGu7NEnEvQJJgdSFPl2qWKkWq5lHMhgiToIiN9w34EBnjYzSYs+VbL5KoYiLNtFFa7BZIKxRED3I32pA==",
-      "dev": true,
-      "requires": {
-        "source-list-map": "^2.0.0",
-        "source-map": "~0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "widest-line": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
-      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^2.1.1"
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
-    "worker-farm": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.6.0.tgz",
-      "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.7"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "write-file-atomic": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
-    "xdg-basedir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-      "dev": true
-    },
-    "xregexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
-      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
-    },
-    "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-      "dev": true
-    },
-    "yallist": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-      "dev": true
-    },
-    "yargs-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^4.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "webpack-command && prettier --write dist/main.js"
+    "build": "rollup --config && prettier --write dist/main.js"
   },
   "keywords": [],
   "author": "Billy Janitsch <billy@kensho.com> (https://billyjanitsch.com/)",
@@ -15,8 +15,10 @@
   },
   "devDependencies": {
     "prettier": "^1.16.4",
-    "terser-webpack-plugin": "^1.2.3",
-    "webpack": "^4.29.6",
-    "webpack-command": "^0.4.2"
+    "rollup": "^1.6.0",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-node-resolve": "^4.0.1",
+    "rollup-plugin-replace": "^2.1.0",
+    "rollup-plugin-terser": "^4.0.4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,21 @@
+import commonjs from 'rollup-plugin-commonjs'
+import replace from 'rollup-plugin-replace'
+import resolve from 'rollup-plugin-node-resolve'
+import {terser} from 'rollup-plugin-terser'
+
+export default {
+  input: 'src/index.js',
+  output: {
+    file: 'dist/main.js',
+    format: 'esm',
+  },
+  external: ['react-is'],
+  plugins: [
+    resolve(),
+    commonjs(),
+    replace({
+      'process.env.NODE_ENV': JSON.stringify('production'),
+    }),
+    terser({mangle: false}),
+  ],
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,0 @@
-const TerserPlugin = require('terser-webpack-plugin')
-
-module.exports = {
-  mode: 'production',
-  optimization: {
-    minimizer: [new TerserPlugin({terserOptions: {mangle: false}})],
-  },
-}


### PR DESCRIPTION
Hi @mjackson!

I'm opening this PR in regards to your suggestion of using Rollup instead of Webpack to get tree-shaking working: https://github.com/ReactTraining/react-router/issues/6608#issuecomment-473462070

Unfortunately, even if we switch from Webpack to Rollup with a proper dead-code elimination config, tree-shaking still doesn't work. Note that `createHashHistory` still unnecessarily [appears in the output](https://github.com/mjackson/react-router-tree-shaking/blob/31af217c276dd36e54afd4735b08c323de8a9c55/dist/main.js#L1239). 😢

(This happens for a similar reason as with Webpack. Rollup is only able to look at a single, [bundled react-router-dom.js](https://unpkg.com/react-router-dom@4.4.0/esm/react-router-dom.js) which contains all of the `history` imports. Its static module analysis isn't smart enough to determine that e.g. `HashRouter`, and therefore `createHashHistory`, are unused. `HashRouter` does get eliminated later in DCE by the minifier, but, by then, the entire `history` module has been included in the bundle. You can confirm this by commenting out the minifier plugin in the Rollup config.)